### PR TITLE
Dynamic bootstrap_action

### DIFF
--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -52,6 +52,13 @@ locals {
       ]
     }
   ]
+
+  bootstrap_action = [
+    {
+      name = "tecton_emr_setup"
+      path = "s3://tecton.ai.public/install_scripts/setup_emr_notebook_cluster.sh"
+    }
+  ]
 }
 
 resource "aws_emr_cluster" "cluster" {
@@ -83,9 +90,14 @@ resource "aws_emr_cluster" "cluster" {
     }
   }
 
-  bootstrap_action {
-    name = "tecton_emr_setup"
-    path = "s3://tecton.ai.public/install_scripts/setup_emr_notebook_cluster.sh"
+  dynamic "bootstrap_action" {
+    iterator = bootstrap_action
+    for_each = concat(local.bootstrap_action, var.extra_bootstrap_actions)
+    content {
+      name = lookup(bootstrap_action.value, "name", null)
+      path = lookup(bootstrap_action.value, "path", null)
+      args = lookup(bootstrap_action.value, "args", null)
+    }
   }
 
   service_role = var.emr_service_role_id

--- a/emr/notebook_cluster/variables.tf
+++ b/emr/notebook_cluster/variables.tf
@@ -34,6 +34,11 @@ variable "emr_service_security_group_id" {
   type        = string
   description = "EMR service security group"
 }
+variable "extra_bootstrap_actions" {
+  type        = list(any)
+  description = "Additional bootstrap actions to perform upon EMR creation"
+  default     = []
+}
 variable "has_glue" {
   type        = bool
   description = "Set to true if AWS Glue Catalog is set up and should be used to load Hive tables"

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -85,6 +85,16 @@ module "notebook_cluster" {
   emr_security_group_id         = module.security_groups.emr_security_group_id
   emr_service_security_group_id = module.security_groups.emr_service_security_group_id
 
+  # OPTIONAL
+  # You can provide custom bootstrap action(s)
+  # to be performed upon notebook cluster creation
+  # extra_bootstrap_actions = [
+  #   {
+  #     name = "name_of_the_step"
+  #     path = "s3://path/to/script.sh"
+  #   }
+  # ]
+
   has_glue        = true
   glue_account_id = local.account_id
 }


### PR DESCRIPTION
Add an option to provide additional bootstrap actions via `extra_bootstrap_actions` module variable.

The variable defaults to an empty list and is concatenated with the default set in locals, so nothing changes on existing clusters, unless some values are provided. 
