### PR TITLE
Allow EMR notebook cluster configuration from variables.

### DIFF
--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -103,7 +103,10 @@ resource "aws_emr_cluster" "cluster" {
 
   service_role = var.emr_service_role_id
 
-  configurations_json = var.has_glue ? jsonencode(concat(local.hive_config, local.base_config)) : jsonencode(local.base_config)
+  configurations_json = (var.has_glue ?
+    jsonencode(concat(local.hive_config, local.base_config, var.extra_cluster_config)) :
+    jsonencode(concat(local.base_config, var.extra_cluster_config))
+  )
 
   step {
     action_on_failure = "TERMINATE_CLUSTER"

--- a/emr/notebook_cluster/variables.tf
+++ b/emr/notebook_cluster/variables.tf
@@ -63,6 +63,11 @@ variable "extra_bootstrap_actions" {
   description = "Additional bootstrap actions to perform upon EMR creation"
   default     = []
 }
+variable "extra_cluster_config" {
+  type        = list(any)
+  description = "Additional EMR cluster configurations"
+  default     = []
+}
 variable "has_glue" {
   type        = bool
   description = "Set to true if AWS Glue Catalog is set up and should be used to load Hive tables"


### PR DESCRIPTION
Added ability to add configurations to `aws_emr_cluster / configurations_json`.

Usage example:
```
extra_cluster_config = [
  {
    Classification : "livy-conf",
    Properties : {
      "livy.server.session.timeout" : "3h"
    }
  }
]
```