### PR TITLE
Add multi-region support to EMR notebook bootstrap

### DIFF
--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -54,10 +54,24 @@ locals {
     }
   ]
 
+  // bootstrap_regions
+  // ---
+  // EMR bootstrapping only supports bootstrap scripts from s3 buckets. The current way the s3
+  // client within EMR is retrieving the bootstrap scripts causes a failure to retrieve the file in
+  // certain regions. Currently Tecton supports serving bootstrap scripts from the following
+  // regions. (including us-west-2 by default) Reach out to customer support for further information.
+  bootstrap_regions = {
+    "eu-central-1" : "-eu-central-1"
+    "us-east-2" : "-us-east-2"
+  }
+
   bootstrap_action = [
     {
       name = "tecton_emr_setup"
-      path = "s3://tecton.ai.public/install_scripts/setup_emr_notebook_cluster_v2.sh"
+      path = format(
+        "s3://tecton.ai.public%s/install_scripts/setup_emr_notebook_cluster_v2.sh",
+        lookup(local.bootstrap_regions, var.region, ""),
+      )
     }
   ]
 }

--- a/templates/spark_policy.json
+++ b/templates/spark_policy.json
@@ -30,7 +30,7 @@
             "Resource": [
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}",
                 "arn:aws:s3:::tecton.ai.databricks-init-scripts",
-                "arn:aws:s3:::tecton.ai.public",
+                "arn:aws:s3:::tecton.ai.public*",
                 "arn:aws:s3:::tecton-materialization-release"
             ]
         },
@@ -54,7 +54,7 @@
             ],
             "Resource": [
                 "arn:aws:s3:::tecton.ai.databricks-init-scripts/*",
-                "arn:aws:s3:::tecton.ai.public/*",
+                "arn:aws:s3:::tecton.ai.public*",
                 "arn:aws:s3:::tecton-materialization-release/*"
             ]
         }


### PR DESCRIPTION
EMR bootstrapping only supports bootstrap scripts from S3 buckets. The current way the S3
client within EMR is retrieving the bootstrap scripts causes a failure to retrieve the file in
certain regions.
This change adds logic to the deployment to redirect the bootstrap url to the appropriate region.