### PR TITLE
additional permissions added to devops eks policy - eks networking

### DIFF
--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -23,6 +23,7 @@
                 "ec2:DescribeVpcs",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInternetGateways",
+                "ec2:DescribeNatGateways",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeLaunchTemplates",
                 "ec2:DescribeLaunchTemplateVersions"
@@ -80,6 +81,7 @@
                 "eks:ListFargateProfiles",
                 "eks:UpdateClusterVersion",
                 "eks:UpdateClusterConfig",
+                "eks:DescribeUpdate",
                 "eks:DeleteCluster"
             ],
             "Resource": [


### PR DESCRIPTION
Adds additional permissions to the devops eks policy, necessary for eks cluster networking