### PR TITLE
Set spark configs to point to the JARs installed during bootstrap

### DIFF
--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -13,7 +13,13 @@ locals {
       Classification : "spark-defaults",
       Properties : {
         "hive.metastore.client.factory.class" : "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
-        "hive.metastore.glue.catalogid" : var.glue_account_id
+        "hive.metastore.glue.catalogid" : var.glue_account_id,
+        # EMR bootrstrap script downloads custom JARs (that are needed by Tecton) under `/home/hadoop/extrajars/`.
+        # Here we append the path to the custom Jars to the `spark.*.extraClassPath` so that Spark context loads them.
+        # Hardcoded paths are the ones that are used by default by EMR. There is no better way of doing this:
+        #   https://aws.amazon.com/premiumsupport/knowledge-center/emr-spark-classnotfoundexception/
+        "spark.driver.extraClassPath" : "/usr/share/aws/emr/emrfs/conf/*:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/*:/usr/lib/hadoop-lzo/lib/*:/usr/lib/hadoop/hadoop-aws.jar:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/goodies/lib/emr-spark-goodies.jar:/usr/share/aws/emr/security/conf:/usr/share/aws/emr/security/lib/*:/usr/share/aws/hmclient/lib/aws-glue-datacatalog-spark-client.jar:/usr/share/java/Hive-JSON-Serde/hive-openx-serde.jar:/usr/share/aws/sagemaker-spark-sdk/lib/sagemaker-spark-sdk.jar:/usr/share/aws/emr/s3select/lib/emr-s3-select-spark-connector.jar:/home/hadoop/extrajars/*",
+        "spark.executor.extraClassPath" : "/usr/share/aws/emr/emrfs/conf/*:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/*:/usr/lib/hadoop-lzo/lib/*:/usr/lib/hadoop/hadoop-aws.jar:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/goodies/lib/emr-spark-goodies.jar:/usr/share/aws/emr/security/conf:/usr/share/aws/emr/security/lib/*:/usr/share/aws/hmclient/lib/aws-glue-datacatalog-spark-client.jar:/usr/share/java/Hive-JSON-Serde/hive-openx-serde.jar:/usr/share/aws/sagemaker-spark-sdk/lib/sagemaker-spark-sdk.jar:/usr/share/aws/emr/s3select/lib/emr-s3-select-spark-connector.jar:/home/hadoop/extrajars/*"
       }
     },
     {


### PR DESCRIPTION
Follow up to https://github.com/tecton-ai/tecton/commit/11e2aaac835c7d03e8c4e64850afd3849d0d1419