### PR TITLE
Remove redundant EMR flag

### DIFF
--- a/emr/vpc_subnets/subnets.tf
+++ b/emr/vpc_subnets/subnets.tf
@@ -4,19 +4,19 @@ data "aws_availability_zones" "available" {
 
 # create a default vpc if vpc_id is not passed in
 resource "aws_vpc" "emr_vpc" {
-  count      = var.use_existing_vpc ? 0 : 1
+  count      = var.existing_vpc_id == null ? 1 : 0
   cidr_block = var.emr_subnet_cidr_prefix
 }
 
 # Add EMR CIDR Block to Existing VPC If any
 resource "aws_vpc_ipv4_cidr_block_association" "secondary_cidr" {
-  count      = var.use_existing_vpc ? 1 : 0
-  vpc_id     = var.emr_vpc_id
+  count      = var.existing_vpc_id == null ? 0 : 1
+  vpc_id     = var.existing_vpc_id
   cidr_block = var.emr_subnet_cidr_prefix
 }
 
 locals {
-  vpc_id                 = var.emr_vpc_id == null ? aws_vpc.emr_vpc[0].id : var.emr_vpc_id
+  vpc_id                 = var.existing_vpc_id == null ? aws_vpc.emr_vpc[0].id : var.existing_vpc_id
   emr_private_cidr_block = cidrsubnet(var.emr_subnet_cidr_prefix, 2, 0)
   public_cidr_block      = cidrsubnet(var.emr_subnet_cidr_prefix, 2, 3)
 }
@@ -33,7 +33,7 @@ resource "aws_subnet" "public_subnet" {
 }
 
 resource "aws_internet_gateway" "internet_gateway" {
-  count  = var.use_existing_vpc == false ? 1 : 0
+  count  = var.internet_gateway_id == null ? 1 : 0
   vpc_id = local.vpc_id
 
   tags = {

--- a/emr/vpc_subnets/variables.tf
+++ b/emr/vpc_subnets/variables.tf
@@ -12,22 +12,16 @@ variable "region" {
   description = "The region for Tecton to use EMR in."
 }
 
-variable "emr_vpc_id" {
+variable "existing_vpc_id" {
   type        = string
   default     = null
-  description = "Id of a pre-existing VPC."
-}
-
-variable "use_existing_vpc" {
-  type        = bool
-  default     = false
-  description = "Use pre existing VPC"
+  description = "Id of a pre-existing VPC to be reused."
 }
 
 variable "internet_gateway_id" {
   type        = string
   default     = null
-  description = "Id of a pre-existing internet gateway."
+  description = "Id of a pre-existing internet gateway to be reused."
 }
 
 variable "emr_subnet_cidr_prefix" {

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -97,8 +97,7 @@ module "subnets" {
   source              = "../emr/vpc_subnets"
   deployment_name     = var.deployment_name
   region              = var.region
-  use_existing_vpc    = true
-  emr_vpc_id          = module.eks_subnets[0].vpc_id
+  existing_vpc_id     = module.eks_subnets[0].vpc_id
   internet_gateway_id = module.eks_subnets[0].internet_gateway_id
   depends_on          = [
     module.eks_subnets


### PR DESCRIPTION
Variable `use_existing_vpc` is redundant and is used to configure both VPC and internet gateway while separate vars are passed for VPC ID and IGW ID.