### PR TITLE
Configure ingress rules to EKS nodes based on public/private NLB

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -42,8 +42,8 @@ variable "elasticache_enabled" {
   default = false
 }
 
-variable "ip_whitelist" {
-  description   = "IP ranges that should be able to access Tecton endpoint"
+variable "allowed_CIDR_blocks" {
+  description   = "CIDR blocks that should be able to access Tecton endpoint. Defaults to `0.0.0.0/0`."
   default       = null
 }
 
@@ -102,10 +102,10 @@ module "security_groups" {
   providers = {
     aws = aws
   }
-  source          = "../eks/security_groups"
-  deployment_name = var.deployment_name
-  vpc_id          = module.subnets.vpc_id
-  ip_whitelist    = var.ip_whitelist
+  source              = "../eks/security_groups"
+  deployment_name     = var.deployment_name
+  vpc_id              = module.subnets.vpc_id
+  allowed_CIDR_blocks = var.allowed_CIDR_blocks
   tags = {"tecton-accessible:${var.deployment_name}": "true"}
 
   # Allow Tecton NLB to be public.

--- a/eks/security_groups/main.tf
+++ b/eks/security_groups/main.tf
@@ -131,10 +131,10 @@ resource "aws_security_group_rule" "lb_to_eks_ingress_port" {
   # will go through the coresponding NAT gateway first.
   # For the private NLB, we also whitelist the private CIDR block(s) of the VPC because
   # the Tecton requests from the VPC will be routed directly to the NLB.
-  cidr_blocks       = var.ip_whitelist == null ? ["0.0.0.0/0"] : (
+  cidr_blocks       = var.allowed_CIDR_blocks == null ? ["0.0.0.0/0"] : (
       var.eks_ingress_load_balancer_public ?
-      concat(var.ip_whitelist, [for ip in var.nat_gateway_ips: "${ip}/32"]) :
-      concat(var.ip_whitelist, var.vpc_cidr_blocks)
+      concat(var.allowed_CIDR_blocks, [for ip in var.nat_gateway_ips: format("%s/32", ip)]) :
+      concat(var.allowed_CIDR_blocks, var.vpc_cidr_blocks)
   )
 
 

--- a/eks/security_groups/main.tf
+++ b/eks/security_groups/main.tf
@@ -1,9 +1,24 @@
+locals {
+  _listener_ports = {
+    # These must match the nodePorts of the Ingress service. They match Tecton's public ingress.
+    # The plaintext is just for redirection to https.
+    plaintext = {
+      port     = 31080
+      protocol = "TCP"
+    }
+    tls = {
+      port     = 31443
+      protocol = "TLS"
+    }
+  }
+}
+
 # RDS
 resource "aws_security_group" "postgres_metadata_db_security" {
   name = "${var.deployment_name}-postgres_metadata_db_security"
 
   description = "Tecton RDS postgres security group"
-  vpc_id      = var.cluster_vpc_id
+  vpc_id      = var.vpc_id
 
   ingress {
     from_port   = 5432
@@ -25,7 +40,7 @@ resource "aws_security_group" "postgres_metadata_db_security" {
 resource "aws_security_group" "tecton_eks_cluster" {
   name        = var.deployment_name
   description = "Cluster communication with worker nodes"
-  vpc_id      = var.cluster_vpc_id
+  vpc_id      = var.vpc_id
 
   egress {
     from_port   = 0
@@ -51,27 +66,11 @@ resource "aws_security_group_rule" "public-ingress-https" {
   type              = "ingress"
 }
 
-locals {
-  _listener_ports = {
-    # These must match the nodePorts of the Ingress service
-    # They match Tecton's public ingress
-    # plaintext is just for redirection to https
-    plaintext = {
-      port     = 31080
-      protocol = "TCP"
-    }
-    tls = {
-      port     = 31443
-      protocol = "TLS"
-    }
-  }
-}
-
 # Worker Nodes
 resource "aws_security_group" "worker_node" {
   name        = "${var.deployment_name}-worker-node"
   description = "Security group for all nodes in the cluster"
-  vpc_id      = var.cluster_vpc_id
+  vpc_id      = var.vpc_id
 
   egress {
     from_port   = 0
@@ -128,6 +127,16 @@ resource "aws_security_group_rule" "lb_to_eks_ingress_port" {
   from_port         = each.value.port
   to_port           = each.value.port
   protocol          = "TCP"
-  cidr_blocks       = var.ip_whitelist
+  # For the public NLB, we also whitelist the public NAT gateway IPs because Tecton requests from the VPC
+  # will go through the coresponding NAT gateway first.
+  # For the private NLB, we also whitelist the private CIDR block(s) of the VPC because
+  # the Tecton requests from the VPC will be routed directly to the NLB.
+  cidr_blocks       = var.ip_whitelist == null ? ["0.0.0.0/0"] : (
+      var.eks_ingress_load_balancer_public ?
+      concat(var.ip_whitelist, [for ip in var.nat_gateway_ips: "${ip}/32"]) :
+      concat(var.ip_whitelist, var.vpc_cidr_blocks)
+  )
+
+
   description       = "Access from the NLB to the K8s Ingress port(s)"
 }

--- a/eks/security_groups/variables.tf
+++ b/eks/security_groups/variables.tf
@@ -11,24 +11,25 @@ variable "vpc_id" {
   description = "Id of the VPC to create the security groups in."
 }
 
-variable "ip_whitelist" {
+variable "allowed_CIDR_blocks" {
   type        = list(string)
-  description = "CIDR blocks that should be able to access the Tecton endpoint."
-  default = null
+  description = "CIDR blocks that should be able to access the Tecton endpoint. Defaults to `0.0.0.0/0`."
+  default     = null
 }
 
 variable "eks_ingress_load_balancer_public" {
   type    = bool
+  description = "Whether or not the Tecton NLB should be accessible by the public internet and have a public IP address."
 }
 
 variable "nat_gateway_ips" {
   type        = list(string)
-  description = "IP addresses of the NAT gateways from the public subnet. Must be set if `ip_whitelist` is set and `eks_ingress_load_balancer_public = true`."
-  default = null
+  description = "IP addresses of the NAT gateways from the public subnet. Must be set if `allowed_CIDR_blocks` is set and `eks_ingress_load_balancer_public = true`."
+  default     = null
 }
 
 variable "vpc_cidr_blocks" {
   type        = list(string)
-  description = "CIDR blocks of the VPC. Must be set if `ip_whitelist` is set and `eks_ingress_load_balancer_public = false`."
-  default = null
+  description = "CIDR blocks of the VPC. Must be set if `allowed_CIDR_blocks` is set and `eks_ingress_load_balancer_public = false`."
+  default     = null
 }

--- a/eks/security_groups/variables.tf
+++ b/eks/security_groups/variables.tf
@@ -6,13 +6,29 @@ variable "tags" {
   type = map(string)
 }
 
-variable "cluster_vpc_id" {
+variable "vpc_id" {
   type        = string
-  description = "Id of the vpc to create the security groups in."
+  description = "Id of the VPC to create the security groups in."
 }
 
 variable "ip_whitelist" {
   type        = list(string)
-  description = "Ip ranges that should be able to access Tecton endpoint"
-  default = ["0.0.0.0/0"]
+  description = "CIDR blocks that should be able to access the Tecton endpoint."
+  default = null
+}
+
+variable "eks_ingress_load_balancer_public" {
+  type    = bool
+}
+
+variable "nat_gateway_ips" {
+  type        = list(string)
+  description = "IP addresses of the NAT gateways from the public subnet. Must be set if `ip_whitelist` is set and `eks_ingress_load_balancer_public = true`."
+  default = null
+}
+
+variable "vpc_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks of the VPC. Must be set if `ip_whitelist` is set and `eks_ingress_load_balancer_public = false`."
+  default = null
 }

--- a/eks/vpc_subnets/outputs.tf
+++ b/eks/vpc_subnets/outputs.tf
@@ -10,7 +10,7 @@ output "eks_subnet_ids" {
   value = aws_subnet.eks_subnet[*].id
 }
 
-output "eks_subnet_ips" {
+output "nat_gateway_ips" {
   value = aws_eip.nat_elastic_ip[*].public_ip
 }
 

--- a/eks/vpc_subnets/subnets.tf
+++ b/eks/vpc_subnets/subnets.tf
@@ -9,7 +9,7 @@ resource "aws_vpc" "eks_vpc" {
 
 locals {
   vpc_id                 = var.eks_vpc_id == null ? aws_vpc.eks_vpc[0].id : var.eks_vpc_id
-  # Only use the half of the CIDR block to have a reserve for the future.
+  # Only use half of the CIDR block to have a reserve for the future.
   eks_private_cidr_block = cidrsubnet(var.eks_subnet_cidr_prefix, 2, 0)
   public_cidr_block      = cidrsubnet(var.eks_subnet_cidr_prefix, 2, 3)
 }

--- a/eks/vpc_subnets/variables.tf
+++ b/eks/vpc_subnets/variables.tf
@@ -20,8 +20,7 @@ variable "eks_vpc_id" {
 
 variable "eks_subnet_cidr_prefix" {
   type        = string
-  default     = "10.64.0.0/16"
-  description = "The cidr block for the private and public subnets for this module to create."
+  description = "The CIDR block for the private and public subnets for this module to create."
   validation {
     condition     = tonumber(regex("/([0-9]+)", var.eks_subnet_cidr_prefix)[0]) <= 18
     error_message = "Subnet must have enough space: the smallest acceptable prefix is /18."

--- a/emr/vpc_subnets/subnets.tf
+++ b/emr/vpc_subnets/subnets.tf
@@ -9,7 +9,7 @@ resource "aws_vpc_ipv4_cidr_block_association" "secondary_cidr" {
 }
 
 locals {
-  # Only use the half of the CIDR block to have a reserve for the future.
+  # Only use half of the CIDR block to have a reserve for the future.
   emr_private_cidr_block = cidrsubnet(var.emr_subnet_cidr_prefix, 1, 0)
 }
 

--- a/emr/vpc_subnets/variables.tf
+++ b/emr/vpc_subnets/variables.tf
@@ -24,8 +24,7 @@ variable "az_name_to_nat_gateway_id" {
 
 variable "emr_subnet_cidr_prefix" {
   type        = string
-  default     = "10.38.0.0/16"
-  description = "The cidr block for the private and public subnets for this module to create."
+  description = "The CIDR block for the private and public subnets for this module to create."
   validation {
     condition     = tonumber(regex("/([0-9]+)", var.emr_subnet_cidr_prefix)[0]) <= 18
     error_message = "Subnet must have enough space: the smallest acceptable prefix is /18."

--- a/emr_sample/README.md
+++ b/emr_sample/README.md
@@ -43,7 +43,7 @@ terraform apply -var-file=<your_file_name>.tfvars
 * `tecton_dataplane_account_role_arn` :
     Role used to run this terraform with. Usually the admin role in the account.
 
-* `ip_whitelist` :
+* `allowed_CIDR_blocks` :
     IP ranges that should be able to access Tecton endpoint. If it's not set, everyone can access the Tecton endpoint (i.e. ingress from `0.0.0.0/0`).
 
 * `tecton_assuming_account_id` :

--- a/emr_sample/README.md
+++ b/emr_sample/README.md
@@ -44,7 +44,7 @@ terraform apply -var-file=<your_file_name>.tfvars
     Role used to run this terraform with. Usually the admin role in the account.
 
 * `ip_whitelist` :
-    IP ranges that should be able to access Tecton endpoint. Currently this defaults to `0.0.0.0/0` so everyone can access the Tecton endpoint
+    IP ranges that should be able to access Tecton endpoint. If it's not set, everyone can access the Tecton endpoint (i.e. ingress from `0.0.0.0/0`).
 
 * `tecton_assuming_account_id` :
     This is the Tecton AWS account ID. Please get this from your Tecton rep.

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -30,6 +30,18 @@ variable "account_id" {
   type = string
 }
 
+variable "eks_subnet_cidr_prefix" {
+  type        = string
+  default     = "10.64.0.0/16"
+  description = "The CIDR block for the private and public subnets of the EKS module."
+}
+
+variable "emr_subnet_cidr_prefix" {
+  type        = string
+  default     = "10.38.0.0/16"
+  description = "The CIDR block for the private subnets of the EMR module."
+}
+
 # By default Redis is not enabled. You can re-run the terraform later
 # with this enabled if you want
 variable "elasticache_enabled" {
@@ -45,7 +57,7 @@ variable "tecton_dataplane_account_role_arn" {
 variable "ip_whitelist" {
   type          = list(string)
   description   = "Ip ranges that should be able to access Tecton endpoint"
-  default       = ["0.0.0.0/0"]
+  default       = null
 }
 
 variable "tecton_assuming_account_id" {
@@ -69,6 +81,7 @@ module "eks_subnets" {
   region          = var.region
   # Please make sure your region has enough AZs: https://aws.amazon.com/about-aws/global-infrastructure/regions_az/
   availability_zone_count = 3
+  eks_subnet_cidr_prefix  = var.eks_subnet_cidr_prefix
 }
 
 module "eks_security_groups" {
@@ -77,9 +90,16 @@ module "eks_security_groups" {
   }
   source            = "../eks/security_groups"
   deployment_name   = var.deployment_name
-  cluster_vpc_id    = module.eks_subnets.vpc_id
-  ip_whitelist      = concat([for ip in module.eks_subnets.eks_subnet_ips: "${ip}/32"], var.ip_whitelist)
+  vpc_id            = module.eks_subnets.vpc_id
+  ip_whitelist      = var.ip_whitelist
   tags              = {"tecton-accessible:${var.deployment_name}": "true"}
+
+  # Allow Tecton NLB to be public.
+  eks_ingress_load_balancer_public = true
+  nat_gateway_ips                  = module.eks_subnets.nat_gateway_ips
+  # Alternatively configure Tecton NLB to be private.
+  # eks_ingress_load_balancer_public = false
+  # vpc_cidr_blocks                  = [var.eks_subnet_cidr_prefix, var.emr_subnet_cidr_prefix]
 }
 
 # EMR Subnets and Security Groups; Uses same VPC as EKS.
@@ -91,6 +111,7 @@ module "emr_subnets" {
   region                    = var.region
   availability_zone_count   = 3
   vpc_id                    = module.eks_subnets.vpc_id
+  emr_subnet_cidr_prefix    = var.emr_subnet_cidr_prefix
   az_name_to_nat_gateway_id = module.eks_subnets.az_name_to_nat_gateway_id
   depends_on                = [
     module.eks_subnets

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -54,9 +54,9 @@ variable "tecton_dataplane_account_role_arn" {
   type = string
 }
 
-variable "ip_whitelist" {
+variable "allowed_CIDR_blocks" {
   type          = list(string)
-  description   = "Ip ranges that should be able to access Tecton endpoint"
+  description   = "CIDR blocks that should be able to access Tecton endpoint. Defaults to `0.0.0.0/0`."
   default       = null
 }
 
@@ -88,11 +88,11 @@ module "eks_security_groups" {
   providers = {
     aws = aws
   }
-  source            = "../eks/security_groups"
-  deployment_name   = var.deployment_name
-  vpc_id            = module.eks_subnets.vpc_id
-  ip_whitelist      = var.ip_whitelist
-  tags              = {"tecton-accessible:${var.deployment_name}": "true"}
+  source              = "../eks/security_groups"
+  deployment_name     = var.deployment_name
+  vpc_id              = module.eks_subnets.vpc_id
+  allowed_CIDR_blocks = var.allowed_CIDR_blocks
+  tags                = {"tecton-accessible:${var.deployment_name}": "true"}
 
   # Allow Tecton NLB to be public.
   eks_ingress_load_balancer_public = true


### PR DESCRIPTION
- For public NLB we need to whitelist NAT gateway IPs while for private NLB we need to whitelist VPC's CIDR block(s).
- Random nits.

Also:
- Note, TF does not yet have a variable validation that can depend on the other variables.
- Tested by running tecton plan on the fresh account.
- Will replicate this to the Tecton TF repo later.