### PR TITLE
[feat][vpc_1] Resources to support EKS VPC endpoint (in own VPC)

### DIFF
--- a/eks/security_groups/outputs.tf
+++ b/eks/security_groups/outputs.tf
@@ -1,3 +1,7 @@
+output "eks_ingress_vpc_endpoint_security_group_id" {
+  value = var.enable_eks_ingress_vpc_endpoint ? aws_security_group.eks_ingress_vpc_endpoint_security_group[0].id : null
+}
+
 output "eks_security_group_id" {
   value = aws_security_group.tecton_eks_cluster.id
 }

--- a/eks/security_groups/variables.tf
+++ b/eks/security_groups/variables.tf
@@ -14,5 +14,11 @@ variable "cluster_vpc_id" {
 variable "ip_whitelist" {
   type        = list(string)
   description = "Ip ranges that should be able to access Tecton endpoint"
-  default = ["0.0.0.0/0"]
+  default     = ["0.0.0.0/0"]
+}
+
+variable "enable_eks_ingress_vpc_endpoint" {
+  default     = true
+  description = "Whether or not to enable resources supporting the EKS Ingress VPC Endpoint for in-VPC communication. Default: true."
+  type        = bool
 }

--- a/emr/security_groups/variables.tf
+++ b/emr/security_groups/variables.tf
@@ -13,6 +13,6 @@ variable "emr_vpc_id" {
 }
 
 variable "vpc_subnet_prefix" {
-  type = string
+  type        = string
   description = "CIDR block prefix to be used for the EMR VPC Subnet"
 }

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -7,29 +7,29 @@ output "region" {
 }
 
 output "cross_account_role_arn" {
-  value = var.is_vpc_deployment ? null : module.tecton.cross_account_role_arn
+  value = var.apply_layer > 1 ? (var.is_vpc_deployment ? null : module.tecton.cross_account_role_arn) : null
 }
 
 output "spark_role_arn" {
-  value = var.is_vpc_deployment ? module.tecton_vpc[0].spark_role_arn : module.tecton.spark_role_arn
+  value = var.apply_layer > 1 ? (var.is_vpc_deployment ? module.tecton_vpc[0].spark_role_arn : module.tecton.spark_role_arn) : null
 }
 
 output "spark_instance_profile_arn" {
-  value = var.is_vpc_deployment ? module.tecton_vpc[0].emr_spark_instance_profile_arn : module.tecton.emr_spark_instance_profile_arn
+  value = var.apply_layer > 1 ? (var.is_vpc_deployment ? module.tecton_vpc[0].emr_spark_instance_profile_arn : module.tecton.emr_spark_instance_profile_arn) : null
 }
 
 output "vpc_id" {
-  value = var.is_vpc_deployment ? module.eks_subnets[0].vpc_id : ""
+  value = var.apply_layer > 1 ? (var.is_vpc_deployment ? module.eks_subnets[0].vpc_id : "") : null
 }
 
 output "eks_subnet_ids" {
-  value = var.is_vpc_deployment ? module.eks_subnets[0].eks_subnet_ids : []
+  value = var.apply_layer > 1 ? (var.is_vpc_deployment ? module.eks_subnets[0].eks_subnet_ids : []) : null
 }
 
 output "public_subnet_ids" {
-  value = var.is_vpc_deployment ? module.eks_subnets[0].public_subnet_ids : []
+  value = var.apply_layer > 1 ? (var.is_vpc_deployment ? module.eks_subnets[0].public_subnet_ids : []) : null
 }
 
 output "security_group_ids" {
-  value = var.is_vpc_deployment ? [module.eks_security_groups[0].eks_security_group_id, module.eks_security_groups[0].eks_worker_security_group_id, module.eks_security_groups[0].rds_security_group_id] : []
+  value = var.apply_layer > 1 ? (var.is_vpc_deployment ? [module.eks_security_groups[0].eks_security_group_id, module.eks_security_groups[0].eks_worker_security_group_id, module.eks_security_groups[0].rds_security_group_id] : []) : null
 }

--- a/templates/devops_eks_vpc_endpoint_policy.json
+++ b/templates/devops_eks_vpc_endpoint_policy.json
@@ -1,0 +1,63 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TagOnCreateTaggedEC2Resources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:vpc-endpoint/*",
+        "arn:aws:ec2:*:*:vpc-endpoint-service/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVpcEndpoint",
+            "CreateVpcEndpointServiceConfiguration"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "VpcEndpointValidateAndAttachToNetworking",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcEndpoint*",
+        "ec2:DescribePrefixLists"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EksVpcEndpointCreate",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVpcEndpointServiceConfiguration",
+        "ec2:CreateVpcEndpoint"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "EksVpcEndpointModify",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVpcEndpointServiceConfigurations",
+        "ec2:ModifyVpcEndpointServicePermissions",
+        "ec2:DeleteVpcEndpoints",
+        "ec2:ModifyVpcEndpoint"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/tecton-accessible:${DEPLOYMENT_NAME}": "true"
+        }
+      }
+    }
+  ]
+}

--- a/templates/devops_policy_1.json
+++ b/templates/devops_policy_1.json
@@ -93,7 +93,7 @@
             ],
             "Resource": [
                 "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:listener/net/tecton-${DEPLOYMENT_NAME}*",
-                "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/tecton-${DEPLOYMENT_NAME}*",
+                "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/${format("%.24s", "tecton-${DEPLOYMENT_NAME}")}*",
                 "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/tecton-${DEPLOYMENT_NAME}*",
                 "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup::autoScalingGroupName/tecton-${DEPLOYMENT_NAME}*",
                 "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/eks-*"

--- a/vpc_deployment/variables.tf
+++ b/vpc_deployment/variables.tf
@@ -16,7 +16,7 @@ variable "tecton_assuming_account_id" {
 }
 
 variable "databricks_account_id" {
-  type = string
+  type    = string
   default = null
 }
 
@@ -39,4 +39,10 @@ variable "emr_spark_role_name" {
   type        = string
   description = "Override the default name Tecton uses for emr spark role"
   default     = null
+}
+
+variable "enable_eks_ingress_vpc_endpoint" {
+  default     = true
+  description = "Whether or not to enable resources supporting the EKS Ingress VPC Endpoint for in-VPC communication. Default: true."
+  type        = bool
 }


### PR DESCRIPTION
## What

**_Note:_** This pull request is into the [`vpc_1`](https://github.com/tecton-ai-ext/tecton-terraform-setup/tree/vpc_1) branch, which is tracking off of the [`vpc_1.0`](https://github.com/tecton-ai-ext/tecton-terraform-setup/releases/tag/vpc_1.0) tag, _not_ the latest from the [`vpc`](https://github.com/tecton-ai-ext/tecton-terraform-setup/tree/vpc) branch. These changes as applied to the latest `vpc` branch can be found in https://github.com/tecton-ai-ext/tecton-terraform-setup/pull/40.

Added resources (security group + IAM policy) which enable the addition of a VPC endpoint within the EKS VPC.

## Why

These resources enable the creation of a VPC endpoint within the EKS VPC, which is used for routing traffic to the Tecton cluster appropriately.

## Notes

This change includes some formatting fixes. Because Terraform does not care about whitespace, I recommend toggling the Github diff to [ignore whitespace changes](https://github.blog/2018-05-01-ignore-white-space-in-code-review/).