### PR TITLE
[feat][vpc] Resources to support EKS VPC endpoint (in own VPC)

### DIFF
--- a/eks/security_groups/outputs.tf
+++ b/eks/security_groups/outputs.tf
@@ -9,3 +9,7 @@ output "eks_worker_security_group_id" {
 output "rds_security_group_id" {
   value = aws_security_group.postgres_metadata_db_security.id
 }
+
+output "eks_ingress_vpc_endpoint_security_group_id" {
+  value = var.enable_eks_ingress_vpc_endpoint ? aws_security_group.eks_ingress_vpc_endpoint_security_group[0].id : null
+}

--- a/eks/security_groups/variables.tf
+++ b/eks/security_groups/variables.tf
@@ -33,3 +33,9 @@ variable "vpc_cidr_blocks" {
   description = "CIDR blocks of the VPC. Must be set if `allowed_CIDR_blocks` is set and `eks_ingress_load_balancer_public = false`."
   default     = null
 }
+
+variable "enable_eks_ingress_vpc_endpoint" {
+  default     = true
+  description = "Whether or not to enable resources supporting the EKS Ingress VPC Endpoint for in-VPC communication. Default: true."
+  type        = bool
+}

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -1,5 +1,5 @@
 locals {
-  tags            = { "tecton-accessible:${var.deployment_name}" : "true" }
+  tags = { "tecton-accessible:${var.deployment_name}" : "true" }
 }
 
 # EKS [Common : Databricks and EMR]
@@ -41,6 +41,15 @@ data "template_file" "devops_eks_policy_json" {
     REGION          = var.region
   }
 }
+# EKS [Common : Databricks and EMR]
+data "template_file" "devops_eks_vpc_endpoint_policy_json" {
+  count = var.enable_eks_ingress_vpc_endpoint ? 1 : 0
+
+  template = file("${path.module}/../templates/devops_eks_vpc_endpoint_policy.json")
+  vars = {
+    DEPLOYMENT_NAME = var.deployment_name
+  }
+}
 
 # Elasticache [Common : Databricks and EMR]
 data "template_file" "devops_elasticache_policy_json" {
@@ -54,7 +63,7 @@ data "template_file" "devops_elasticache_policy_json" {
 
 # Spark : Databricks
 data "template_file" "spark_policy_json" {
-  count  = var.create_emr_roles ? 0 : 1
+  count    = var.create_emr_roles ? 0 : 1
   template = file("${path.module}/../templates/spark_policy.json")
   vars = {
     ACCOUNT_ID      = var.account_id
@@ -65,7 +74,7 @@ data "template_file" "spark_policy_json" {
 
 # Spark : Databricks
 data "template_file" "cross_account_databricks_json" {
-  count  = var.create_emr_roles ? 0 : 1
+  count    = var.create_emr_roles ? 0 : 1
   template = file("${path.module}/../templates/cross_account_databricks.json")
   vars = {
     ACCOUNT_ID      = var.account_id
@@ -112,9 +121,9 @@ data "template_file" "emr_access_policy_json" {
 
 # DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_role" "devops_role" {
-  name                 = "tecton-${var.deployment_name}-devops-role"
-  tags                 = local.tags
-  assume_role_policy   = <<POLICY
+  name               = "tecton-${var.deployment_name}-devops-role"
+  tags               = local.tags
+  assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -152,6 +161,15 @@ resource "aws_iam_policy" "devops_eks_policy" {
 }
 
 # DEVOPS [Common : Databricks and EMR]
+resource "aws_iam_policy" "devops_eks_vpc_endpoint_policy" {
+  count = var.enable_eks_ingress_vpc_endpoint ? 1 : 0
+
+  name   = "tecton-${var.deployment_name}-devops-eks-vpce"
+  policy = data.template_file.devops_eks_vpc_endpoint_policy_json[0].rendered
+  tags   = local.tags
+}
+
+# DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_policy" "devops_elasticache_policy" {
   count  = var.elasticache_enabled ? 1 : 0
   name   = "tecton-${var.deployment_name}-devops-elasticache-policy"
@@ -179,6 +197,14 @@ resource "aws_iam_role_policy_attachment" "devops_eks_policy_attachment" {
 }
 
 # DEVOPS [Common : Databricks and EMR]
+resource "aws_iam_role_policy_attachment" "devops_eks_vpc_endpoint_policy_attachment" {
+  count = var.enable_eks_ingress_vpc_endpoint ? 1 : 0
+
+  policy_arn = aws_iam_policy.devops_eks_vpc_endpoint_policy[0].arn
+  role       = aws_iam_role.devops_role.name
+}
+
+# DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_role_policy_attachment" "devops_elasticache_policy_attachment" {
   count      = var.elasticache_enabled ? 1 : 0
   policy_arn = aws_iam_policy.devops_elasticache_policy[0].arn
@@ -187,9 +213,9 @@ resource "aws_iam_role_policy_attachment" "devops_elasticache_policy_attachment"
 
 # EKS MANAGEMENT [Common : Databricks and EMR]
 resource "aws_iam_role" "eks_management_role" {
-  name                 = "tecton-${var.deployment_name}-eks-management-role"
-  tags                 = local.tags
-  assume_role_policy   = <<POLICY
+  name               = "tecton-${var.deployment_name}-eks-management-role"
+  tags               = local.tags
+  assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -207,19 +233,19 @@ POLICY
 
 # EKS MANAGEMENT [Common : Databricks and EMR]
 resource "aws_iam_role_policy_attachment" "eks_management_policy" {
-    for_each = toset([
-        "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
-        "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
-    ])
-    policy_arn = each.value
-    role = aws_iam_role.eks_management_role.name
+  for_each = toset([
+    "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+  ])
+  policy_arn = each.value
+  role       = aws_iam_role.eks_management_role.name
 }
 
 # EKS NODE [Common : Databricks and EMR]
 resource "aws_iam_role" "eks_node_role" {
-  name                 = "tecton-${var.deployment_name}-eks-worker-role"
-  tags                 = local.tags
-  assume_role_policy   = <<POLICY
+  name               = "tecton-${var.deployment_name}-eks-worker-role"
+  tags               = local.tags
+  assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -250,14 +276,14 @@ resource "aws_iam_role_policy_attachment" "eks_node_policy_attachment" {
 
 # EKS NODE [Common : Databricks and EMR]
 resource "aws_iam_role_policy_attachment" "eks_node_policy" {
-    for_each = toset([
-        "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-        "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
-        "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
-        "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
-    ])
-    policy_arn = each.value
-    role = aws_iam_role.eks_node_role.name
+  for_each = toset([
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+  ])
+  policy_arn = each.value
+  role       = aws_iam_role.eks_node_role.name
 }
 
 # Spark Access Policy : EMR only
@@ -282,16 +308,16 @@ provider "aws" {
 # Spark Common : Databricks and EMR
 resource "aws_iam_policy" "common_spark_policy" {
   provider = aws.databricks-account
-  name   = "tecton-${var.deployment_name}-common-spark-policy"
-  policy = var.create_emr_roles ? data.template_file.emr_spark_policy_json[0].rendered : data.template_file.spark_policy_json[0].rendered
-  tags   = local.tags
+  name     = "tecton-${var.deployment_name}-common-spark-policy"
+  policy   = var.create_emr_roles ? data.template_file.emr_spark_policy_json[0].rendered : data.template_file.spark_policy_json[0].rendered
+  tags     = local.tags
 }
 
 # Spark Common : Databricks and EMR
 resource "aws_iam_role_policy_attachment" "common_spark_policy_attachment" {
-  provider    = aws.databricks-account
-  policy_arn  = aws_iam_policy.common_spark_policy.arn
-  role        = var.create_emr_roles ? (var.emr_spark_role_name != null ? var.emr_spark_role_name : "tecton-${var.deployment_name}-emr-spark-role") : var.spark_role_name
+  provider   = aws.databricks-account
+  policy_arn = aws_iam_policy.common_spark_policy.arn
+  role       = var.create_emr_roles ? (var.emr_spark_role_name != null ? var.emr_spark_role_name : "tecton-${var.deployment_name}-emr-spark-role") : var.spark_role_name
 }
 
 # CROSS-ACCOUNT ACCESS FOR SPARK : Databricks
@@ -326,9 +352,9 @@ resource "aws_iam_policy" "cross_account_databricks_policy" {
 
 # CROSS-ACCOUNT ACCESS FOR SPARK : Databricks
 resource "aws_iam_role_policy_attachment" "cross_account_databricks_policy_attachment" {
-  count       = var.create_emr_roles ? 0 : 1
-  policy_arn  = aws_iam_policy.cross_account_databricks_policy[0].arn
-  role        = aws_iam_role.spark_cross_account_role[0].name
+  count      = var.create_emr_roles ? 0 : 1
+  policy_arn = aws_iam_policy.cross_account_databricks_policy[0].arn
+  role       = aws_iam_role.spark_cross_account_role[0].name
 }
 
 

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -16,7 +16,7 @@ variable "tecton_assuming_account_id" {
 }
 
 variable "databricks_account_id" {
-  type = string
+  type    = string
   default = null
 }
 
@@ -39,4 +39,10 @@ variable "emr_spark_role_name" {
   type        = string
   description = "Override the default name Tecton uses for emr spark role"
   default     = null
+}
+
+variable "enable_eks_ingress_vpc_endpoint" {
+  default     = true
+  description = "Whether or not to enable resources supporting the EKS Ingress VPC Endpoint for in-VPC communication. Default: true."
+  type        = bool
 }

--- a/templates/devops_eks_vpc_endpoint_policy.json
+++ b/templates/devops_eks_vpc_endpoint_policy.json
@@ -1,0 +1,63 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TagOnCreateTaggedEC2Resources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:vpc-endpoint/*",
+        "arn:aws:ec2:*:*:vpc-endpoint-service/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVpcEndpoint",
+            "CreateVpcEndpointServiceConfiguration"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "VpcEndpointValidateAndAttachToNetworking",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcEndpoint*",
+        "ec2:DescribePrefixLists"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EksVpcEndpointCreate",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVpcEndpointServiceConfiguration",
+        "ec2:CreateVpcEndpoint"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "EksVpcEndpointModify",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVpcEndpointServiceConfigurations",
+        "ec2:ModifyVpcEndpointServicePermissions",
+        "ec2:DeleteVpcEndpoints",
+        "ec2:ModifyVpcEndpoint"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/tecton-accessible:${DEPLOYMENT_NAME}": "true"
+        }
+      }
+    }
+  ]
+}

--- a/templates/devops_policy_1.json
+++ b/templates/devops_policy_1.json
@@ -93,7 +93,7 @@
             ],
             "Resource": [
                 "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:listener/net/tecton-${DEPLOYMENT_NAME}*",
-                "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/tecton-${DEPLOYMENT_NAME}*",
+                "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/tecton-${format(\"%.24s\", \"tecton-${DEPLOYMENT_NAME}\")}*",
                 "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/tecton-${DEPLOYMENT_NAME}*",
                 "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup::autoScalingGroupName/tecton-${DEPLOYMENT_NAME}*",
                 "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/eks-*"


### PR DESCRIPTION
## What

**_Note:_** This pull request is into the [`vpc`](https://github.com/tecton-ai-ext/tecton-terraform-setup/tree/vpc) branch. Additional changes were applied to the `vpc_1` branch in https://github.com/tecton-ai-ext/tecton-terraform-setup/pull/37

Added resources (security group + IAM policy) which enable the addition of a VPC endpoint within the EKS VPC.

## Why

These resources enable the creation of a VPC endpoint within the EKS VPC, which is used for routing traffic to the Tecton cluster appropriately.

## Notes

This change includes some formatting fixes. Because Terraform does not care about whitespace, I recommend toggling the Github diff to [ignore whitespace changes](https://github.blog/2018-05-01-ignore-white-space-in-code-review/).