### PR TITLE
EMR Notebook Cluster: Support boostrapping from eu-west-1

### DIFF
--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -61,8 +61,9 @@ locals {
   // certain regions. Currently Tecton supports serving bootstrap scripts from the following
   // regions. (including us-west-2 by default) Reach out to customer support for further information.
   bootstrap_regions = {
-    "eu-central-1" : "-eu-central-1"
-    "us-east-2" : "-us-east-2"
+    "eu-central-1" : "-eu-central-1",
+    "eu-west-1" : "-eu-west-1",
+    "us-east-2" : "-us-east-2",
   }
 
   bootstrap_action = [


### PR DESCRIPTION
Added eu-west-1 to the supported regions to bootstrap the EMR notebook cluster from.