### PR TITLE
Adds additional es describe permissions as required by the AWS API

### DIFF
--- a/templates/devops_policy_2.json
+++ b/templates/devops_policy_2.json
@@ -66,6 +66,8 @@
             "Action": [
                 "es:CreateDomain",
                 "es:DescribeElasticsearchDomain",
+                "es:DescribeElasticsearchDomainConfig",
+                "es:DescribeDomainConfig",
                 "es:ListTags",
                 "es:DeleteElasticsearchDomain"
             ],


### PR DESCRIPTION
VPC Deployment: Adding additional es:describe permissions to the devops role as updates to the AWS API (and Terraform) requires these permissions to query state.