### PR TITLE
feat: set bucket acl to BucketOwnerEnforced

### DIFF
--- a/deployment/buckets.tf
+++ b/deployment/buckets.tf
@@ -34,3 +34,11 @@ resource "aws_s3_bucket_policy" "read-only-access" {
     ]
   })
 }
+
+resource "aws_s3_bucket_ownership_controls" "bucket_owner_enforced" {
+  bucket = aws_s3_bucket.tecton.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}


### PR DESCRIPTION
# What

Added a new resource `aws_s3_bucket_ownership_controls` which sets the object ownership on the Tecton bucket to `BucketOwnerEnforced`

# Why

This is necessary to ensure that files all have the correct uniform permission