### PR TITLE
feat: add cluster s3 bucket

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -58,6 +58,12 @@ variable "enable_eks_ingress_vpc_endpoint" {
   type        = bool
 }
 
+variable "additional_s3_read_only_principals" {
+  type        = list(string)
+  default     = []
+  description = "Additional principals that should be able to access (read-only) the cluster s3 bucket."
+}
+
 provider "aws" {
   region = var.region
   assume_role {
@@ -122,4 +128,10 @@ module "security_groups" {
   # Alternatively configure Tecton NLB to be private.
   # eks_ingress_load_balancer_public = false
   # vpc_cidr_blocks                  = [var.eks_subnet_cidr_prefix]
+}
+
+module "s3" {
+  source                             = "../s3"
+  deployment_name                    = var.deployment_name
+  additional_s3_read_only_principals = var.additional_s3_read_only_principals
 }

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -78,6 +78,12 @@ variable "enable_eks_ingress_vpc_endpoint" {
   type        = bool
 }
 
+variable "additional_s3_read_only_principals" {
+  type        = list(string)
+  default     = []
+  description = "Additional principals that should be able to access (read-only) the cluster s3 bucket."
+}
+
 module "eks_subnets" {
   providers = {
     aws = aws
@@ -135,6 +141,12 @@ module "emr_security_groups" {
   depends_on = [
     module.eks_subnets
   ]
+}
+
+module "s3" {
+  source                             = "../s3"
+  deployment_name                    = var.deployment_name
+  additional_s3_read_only_principals = var.additional_s3_read_only_principals
 }
 
 module "roles" {

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,0 +1,48 @@
+locals {
+  tags = { "tecton-accessible:${var.deployment_name}" : "true" }
+}
+
+resource "aws_s3_bucket" "tecton" {
+  bucket = "tecton-${var.deployment_name}"
+  acl    = "private"
+  tags   = local.tags
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  lifecycle {
+    ignore_changes = [lifecycle_rule]
+  }
+}
+
+resource "aws_s3_bucket_policy" "read-only-access" {
+  count  = length(var.additional_s3_read_only_principals) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.tecton.bucket
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "BucketPolicy"
+    Statement = [
+      {
+        Sid       = "AllowReadOnly"
+        Effect    = "Allow"
+        Principal = var.additional_s3_read_only_principals
+        Action    = ["s3:Get*", "s3:List*"]
+        Resource = [
+          aws_s3_bucket.tecton.arn,
+          "${aws_s3_bucket.tecton.arn}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_ownership_controls" "bucket_owner_enforced" {
+  bucket = aws_s3_bucket.tecton.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -1,0 +1,9 @@
+variable "deployment_name" {
+  type = string
+}
+
+variable "additional_s3_read_only_principals" {
+  type        = list(string)
+  default     = []
+  description = "Additional principals that should be able to access (read-only) the cluster s3 bucket."
+}


### PR DESCRIPTION
# What

Adds the cluster s3 bucket resources

# Why

The resource was removed as part of the VPC branch cleanup and never added back. Resource matches that from the master branch [here](https://github.com/tecton-ai-ext/tecton-terraform-setup/blob/master/deployment/buckets.tf). 