### PR TITLE
feat: add option to set tags for offline storage

### DIFF
--- a/deployment/buckets.tf
+++ b/deployment/buckets.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "tecton" {
   bucket = "tecton-${var.deployment_name}"
   acl    = "private"
-  tags   = "${merge(local.tags, var.additional_offline_storage_tags)}"
+  tags   = merge(local.tags, var.additional_offline_storage_tags)
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {

--- a/deployment/buckets.tf
+++ b/deployment/buckets.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "tecton" {
   bucket = "tecton-${var.deployment_name}"
   acl    = "private"
-  tags   = local.tags
+  tags   = "${merge(local.tags, var.additional_offline_storage_tags)}"
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -32,3 +32,9 @@ variable "additional_s3_read_only_principals" {
   type    = list(string)
   default = []
 }
+
+variable "additional_offline_storage_tags" {
+  type        = map(string)
+  description = "Additional tags for offline storage (S3 bucket)"
+  default     = {}
+}


### PR DESCRIPTION
# What

Add an option to set tags for offline storage (S3 bucket) inside the `deployment` module using the variable `additional_offline_storage_tags`.

# Why

To give an option for Users of the `deployment` module to set proper tags based on the company requirements.
