### PR TITLE
feat: Enable EMR notebook cluster logs access when debugging enabled 

### DIFF
--- a/emr/debugging/buckets.tf
+++ b/emr/debugging/buckets.tf
@@ -1,0 +1,21 @@
+## DEBUG ACCESS TO NOTEBOOK CLUSTER LOGS
+resource "aws_s3_bucket_policy" "notebook_logs_read_only_access" {
+  bucket = var.log_uri_bucket
+  policy = data.aws_iam_policy_document.notebook_logs_access_policy.json
+}
+
+data "aws_iam_policy_document" "notebook_logs_access_policy" {
+  statement {
+    actions = ["s3:Get*", "s3:List*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_id}:role/${var.cross_account_role_name}"]
+    }
+
+    resources = [
+      var.log_uri_bucket_arn,
+      "${var.log_uri_bucket_arn}/*",
+    ]
+  }
+}

--- a/emr/debugging/variables.tf
+++ b/emr/debugging/variables.tf
@@ -5,3 +5,14 @@ variable "cross_account_role_name" {
   type        = string
   description = "Set to your Tecton cross_account_role if you want to add permissions for Tecton engineers to debug your notebook code"
 }
+variable "account_id" {
+  type = string
+}
+variable "log_uri_bucket" {
+  type        = string
+  description = "The bucket name for the notebook cluster logs"
+}
+variable "log_uri_bucket_arn" {
+  type        = string
+  description = "The bucket ARN for the notebook cluster logs"
+}

--- a/emr/notebook_cluster/buckets.tf
+++ b/emr/notebook_cluster/buckets.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "tecton_notebook_cluster_logs" {
+  bucket = "tecton-${var.deployment_name}-notebook"
+  acl    = "private"
+  tags = {
+    notebook                                   = "true",
+    "tecton-accessible:${var.deployment_name}" = "false",
+    tecton-owned                               = "false"
+  }
+}

--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -83,6 +83,8 @@ resource "aws_emr_cluster" "cluster" {
 
   applications = ["Spark", "Livy", "Hive", "JupyterEnterpriseGateway"]
 
+  log_uri = "s3n://${aws_s3_bucket.tecton_notebook_cluster_logs.bucket}/"
+
   ec2_attributes {
     subnet_id                         = var.subnet_id
     emr_managed_master_security_group = var.emr_security_group_id

--- a/emr/notebook_cluster/outputs.tf
+++ b/emr/notebook_cluster/outputs.tf
@@ -1,3 +1,6 @@
 output "cluster_id" {
   value = aws_emr_cluster.cluster.id
 }
+output "logs_s3_bucket" {
+  value = aws_s3_bucket.tecton_notebook_cluster_logs
+}

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -96,7 +96,8 @@ module "notebook_cluster" {
 
 # This module adds some IAM privileges to enable your Tecton technical support
 # reps to open and execute EMR notebooks in your account to help troubleshoot
-# or test code you are developing.
+# or test code you are developing. It also will give Tecton access to your EMR
+# notebook cluster logs.
 #
 # Enable this module by setting count = 1
 module "emr_debugging" {
@@ -105,6 +106,9 @@ module "emr_debugging" {
   count                   = 0
   deployment_name         = local.deployment_name
   cross_account_role_name = module.tecton.cross_account_role_name
+  account_id              = local.account_id
+  log_uri_bucket          = module.notebook_cluster[0].logs_s3_bucket.bucket
+  log_uri_bucket_arn      = module.notebook_cluster[0].logs_s3_bucket.arn
 }
 
 ##############################################################################################

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -17,5 +17,5 @@ output "spark_instance_profile_arn" {
   value = module.tecton.emr_spark_instance_profile_arn
 }
 output "notebook_cluster_id" {
-  value = local.notebook_cluster_count > 0 ? module.notebook_cluster.cluster_id : ""
+  value = local.notebook_cluster_count > 0 ? module.notebook_cluster[0].cluster_id : ""
 }


### PR DESCRIPTION
This will do two things:
- The EMR notebook cluster is now configured by default to have a logs bucket (that Tecton does not have access to)
- When the `emr_debugging` module is enabled, then Tecton is given access to said logs bucket.

A disadvantage here is that the customer will need to grant additional access to the bucket if they want to read the logs. An alternative is to only use that `log_uri` bucket if `emr_debugging` is turned on, but that would force a recreation of the notebook cluster. 