### PR TITLE
fix: Give EMR spark role access to notebook cluster logs s3 bucket

### DIFF
--- a/emr/notebook_cluster/roles.tf
+++ b/emr/notebook_cluster/roles.tf
@@ -1,16 +1,16 @@
 ## ALLOW SPARK ROLE TO ARCHIVE TO S3
 resource "aws_iam_policy" "notebook_s3_archival_access" {
-  name = "tecton-${var.deployment_name}-notebook-cluster-s3-archival-policy"
+  name = "tecton-${var.deployment_name}-notebook-cluster-s3-archival"
 
-  policy = data.aws_iam_policy_document.notebook_s3_archival_access_policy.json
+  policy = data.aws_iam_policy_document.notebook_s3_archival_access.json
 }
 
-resource "aws_iam_role_policy_attachment" "tecton_spark_s3_archival_access_policy" {
+resource "aws_iam_role_policy_attachment" "tecton_spark_s3_archival_access" {
   role       = var.instance_profile_arn
   policy_arn = aws_iam_policy.notebook_s3_archival_access.arn
 }
 
-data "aws_iam_policy_document" "notebook_s3_archival_access_policy" {
+data "aws_iam_policy_document" "notebook_s3_archival_access" {
   statement {
     actions = ["s3:PutObject"]
 

--- a/emr/notebook_cluster/roles.tf
+++ b/emr/notebook_cluster/roles.tf
@@ -1,0 +1,22 @@
+## ALLOW SPARK ROLE TO ARCHIVE TO S3
+resource "aws_iam_policy" "notebook_s3_archival_access" {
+  name = "tecton-${var.deployment_name}-notebook-cluster-s3-archival-policy"
+
+  policy = data.aws_iam_policy_document.notebook_s3_archival_access_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "tecton_spark_s3_archival_access_policy" {
+  role       = var.instance_profile_arn
+  policy_arn = aws_iam_policy.notebook_s3_archival_access.arn
+}
+
+data "aws_iam_policy_document" "notebook_s3_archival_access_policy" {
+  statement {
+    actions = ["s3:PutObject"]
+
+    resources = [
+      aws_s3_bucket.tecton_notebook_cluster_logs.arn,
+      "${aws_s3_bucket.tecton_notebook_cluster_logs.arn}/*",
+    ]
+  }
+}

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -59,6 +59,9 @@ module "subnets" {
 locals {
   # Set count = 1 once your Tecton rep confirms Tecton has been deployed in your account
   notebook_cluster_count = 0
+
+  # Set count = 1 to allow Tecton to debug EMR clusters
+  emr_debugging_count = 0
 }
 
 module "notebook_cluster" {
@@ -103,7 +106,8 @@ module "notebook_cluster" {
 module "emr_debugging" {
   source = "../emr/debugging"
 
-  count                   = 0
+  count = local.emr_debugging_count
+
   deployment_name         = local.deployment_name
   cross_account_role_name = module.tecton.cross_account_role_name
   account_id              = local.account_id


### PR DESCRIPTION
The previous PR #57 didn't give access to the spark role, so the logs bucket was not being populated. This fixes that