### PR TITLE
chore: Use external id in the devops role assume policy

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -97,10 +97,10 @@ module "subnets" {
   providers = {
     aws = aws
   }
-  source                 = "../eks/vpc_subnets"
-  deployment_name        = var.deployment_name
-  region                 = var.region
-  eks_subnet_cidr_prefix = var.eks_subnet_cidr_prefix
+  source                  = "../eks/vpc_subnets"
+  deployment_name         = var.deployment_name
+  region                  = var.region
+  eks_subnet_cidr_prefix  = var.eks_subnet_cidr_prefix
   # Please make sure your region has enough AZs: https://aws.amazon.com/about-aws/global-infrastructure/regions_az/
   availability_zone_count = 3
 }

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -154,6 +154,7 @@ module "roles" {
   region                          = var.region
   create_emr_roles                = true
   elasticache_enabled             = var.elasticache_enabled
+  external_id = random_id.external_id.id
 }
 
 module "notebook_cluster" {

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -82,9 +82,9 @@ module "eks_subnets" {
   providers = {
     aws = aws
   }
-  source          = "../eks/vpc_subnets"
-  deployment_name = var.deployment_name
-  region          = var.region
+  source                  = "../eks/vpc_subnets"
+  deployment_name         = var.deployment_name
+  region                  = var.region
   # Please make sure your region has enough AZs: https://aws.amazon.com/about-aws/global-infrastructure/regions_az/
   availability_zone_count = 3
   eks_subnet_cidr_prefix  = var.eks_subnet_cidr_prefix
@@ -120,7 +120,7 @@ module "emr_subnets" {
   vpc_id                    = module.eks_subnets.vpc_id
   emr_subnet_cidr_prefix    = var.emr_subnet_cidr_prefix
   az_name_to_nat_gateway_id = module.eks_subnets.az_name_to_nat_gateway_id
-  depends_on = [
+  depends_on                = [
     module.eks_subnets
   ]
 }
@@ -132,7 +132,7 @@ module "emr_security_groups" {
   region            = var.region
   emr_vpc_id        = module.eks_subnets.vpc_id
   vpc_subnet_prefix = module.eks_subnets.vpc_subnet_prefix
-  depends_on = [
+  depends_on        = [
     module.eks_subnets
   ]
 }
@@ -154,7 +154,7 @@ module "roles" {
   region                          = var.region
   create_emr_roles                = true
   elasticache_enabled             = var.elasticache_enabled
-  external_id = random_id.external_id.id
+  external_id                     = random_id.external_id.id
 }
 
 module "notebook_cluster" {

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -5,7 +5,7 @@ locals {
 # EKS [Common : Databricks and EMR]
 data "template_file" "eks_policy_json" {
   template = file("${path.module}/../templates/eks_policy.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -15,7 +15,7 @@ data "template_file" "eks_policy_json" {
 # EKS [Common : Databricks and EMR]
 data "template_file" "devops_policy_json_1" {
   template = file("${path.module}/../templates/devops_policy_1.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID             = var.account_id
     DEPLOYMENT_NAME        = var.deployment_name
     DEPLOYMENT_NAME_CONCAT = format("%.24s", "tecton-${var.deployment_name}")
@@ -26,7 +26,7 @@ data "template_file" "devops_policy_json_1" {
 # EKS [Common : Databricks and EMR]
 data "template_file" "devops_policy_json_2" {
   template = file("${path.module}/../templates/devops_policy_2.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -36,7 +36,7 @@ data "template_file" "devops_policy_json_2" {
 # EKS [Common : Databricks and EMR]
 data "template_file" "devops_eks_policy_json" {
   template = file("${path.module}/../templates/devops_eks_policy.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -47,7 +47,7 @@ data "template_file" "devops_eks_vpc_endpoint_policy_json" {
   count = var.enable_eks_ingress_vpc_endpoint ? 1 : 0
 
   template = file("${path.module}/../templates/devops_eks_vpc_endpoint_policy.json")
-  vars = {
+  vars     = {
     DEPLOYMENT_NAME = var.deployment_name
   }
 }
@@ -55,7 +55,7 @@ data "template_file" "devops_eks_vpc_endpoint_policy_json" {
 # Elasticache [Common : Databricks and EMR]
 data "template_file" "devops_elasticache_policy_json" {
   template = file("${path.module}/../templates/devops_elasticache_policy.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -64,16 +64,16 @@ data "template_file" "devops_elasticache_policy_json" {
 
 data "template_file" "assume_role_policy" {
   template = file("${path.module}/../templates/assume_role.json")
-  vars = {
-    ASSUMING_ACCOUNT_ID      = var.tecton_assuming_account_id
+  vars     = {
+    ASSUMING_ACCOUNT_ID = var.tecton_assuming_account_id
   }
 }
 
 data "template_file" "assume_role_external_id_policy" {
   template = file("${path.module}/../templates/assume_role_external_id.json")
-  vars = {
-    ASSUMING_ACCOUNT_ID      = var.tecton_assuming_account_id
-    EXTERNAL_ID = var.external_id
+  vars     = {
+    ASSUMING_ACCOUNT_ID = var.tecton_assuming_account_id
+    EXTERNAL_ID         = var.external_id
   }
 }
 
@@ -81,7 +81,7 @@ data "template_file" "assume_role_external_id_policy" {
 data "template_file" "spark_policy_json" {
   count    = var.create_emr_roles ? 0 : 1
   template = file("${path.module}/../templates/spark_policy.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -92,7 +92,7 @@ data "template_file" "spark_policy_json" {
 data "template_file" "cross_account_databricks_json" {
   count    = var.create_emr_roles ? 0 : 1
   template = file("${path.module}/../templates/cross_account_databricks.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -103,7 +103,7 @@ data "template_file" "cross_account_databricks_json" {
 data "template_file" "emr_spark_policy_json" {
   count    = var.create_emr_roles ? 1 : 0
   template = file("${path.module}/../templates/emr_spark_policy.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -114,7 +114,7 @@ data "template_file" "emr_spark_policy_json" {
 data "template_file" "emr_master_policy_json" {
   count    = var.create_emr_roles ? 1 : 0
   template = file("${path.module}/../templates/emr_master_policy.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
@@ -126,7 +126,7 @@ data "template_file" "emr_master_policy_json" {
 data "template_file" "emr_access_policy_json" {
   count    = var.create_emr_roles ? 1 : 0
   template = file("${path.module}/../templates/emr_ca_policy.json")
-  vars = {
+  vars     = {
     ACCOUNT_ID       = var.account_id
     DEPLOYMENT_NAME  = var.deployment_name
     REGION           = var.region

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -46,3 +46,9 @@ variable "enable_eks_ingress_vpc_endpoint" {
   description = "Whether or not to enable resources supporting the EKS Ingress VPC Endpoint for in-VPC communication. Default: true."
   type        = bool
 }
+
+variable "external_id" {
+  default = ""
+  description = "The external id that should be usd by Tecton when assuming the devops role."
+  type = string
+}

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -48,7 +48,7 @@ variable "enable_eks_ingress_vpc_endpoint" {
 }
 
 variable "external_id" {
-  default = ""
+  default     = ""
   description = "The external id that should be usd by Tecton when assuming the devops role."
-  type = string
+  type        = string
 }

--- a/templates/assume_role.json
+++ b/templates/assume_role.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${ASSUMING_ACCOUNT_ID}:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/templates/assume_role_external_id.json
+++ b/templates/assume_role_external_id.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${ASSUMING_ACCOUNT_ID}:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {"StringEquals": {"sts:ExternalId": "${EXTERNAL_ID}"}}
+    }
+  ]
+}


### PR DESCRIPTION
When terraforming VPC deployments, we *need* to use an external ID. This is the error we get:

```
Exception: Customer owned accounts MUST have an external ID. Do not bypass this for security reasons. See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
```

We even go as far as to create the external ID, but we don't use it in the assume role policy, and that just adds more manual steps & friction for customers.

This PR automates that.