### PR TITLE
fix: Remove extra tecton- prefix from load balancer name

### DIFF
--- a/templates/devops_policy_1.json
+++ b/templates/devops_policy_1.json
@@ -93,7 +93,7 @@
             ],
             "Resource": [
                 "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:listener/net/tecton-${DEPLOYMENT_NAME}*",
-                "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/tecton-${DEPLOYMENT_NAME_CONCAT}*",
+                "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/${DEPLOYMENT_NAME_CONCAT}*",
                 "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/tecton-${DEPLOYMENT_NAME}*",
                 "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup::autoScalingGroupName/tecton-${DEPLOYMENT_NAME}*",
                 "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/eks-*"


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

DEPLOYMENT_NAME_CONCAT already has a `tecton-` prefix, which makes the name of the loadbalancer `tecton-tecton-<>`