### PR TITLE
fix: Update permissions needed for management of ingestion api

### DIFF
--- a/templates/online_ingest_management_policy.json
+++ b/templates/online_ingest_management_policy.json
@@ -5,19 +5,20 @@
       "Sid": "UpdateALBOnLambdaDeployments",
       "Effect": "Allow",
       "Action": [
-        "elasticloadbalancing:DescribeLoadBalancers",
-        "elasticloadbalancing:DescribeTags",
-        "elasticloadbalancing:DescribeListeners",
-        "elasticloadbalancing:DescribeRules",
         "elasticloadbalancing:CreateRule",
         "elasticloadbalancing:CreateTargetGroup",
-        "elasticloadbalancing:DescribeTargetGroups",
-        "elasticloadbalancing:DescribeTargetHealth",
         "elasticloadbalancing:RegisterTargets"
       ],
       "Resource": [
-        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/app/${DEPLOYMENT_NAME}-${REGION}*"
-      ]
+        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:listener/net/tecton-${DEPLOYMENT_NAME}*",
+        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:listener/app/tecton-${DEPLOYMENT_NAME}*",
+        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/tecton-*",
+        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/app/tecton-*",
+        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/tecton-${DEPLOYMENT_NAME}*",
+        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/${DEPLOYMENT_NAME}*",
+        "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup::autoScalingGroupName/tecton-${DEPLOYMENT_NAME}*",
+        "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/eks-*"
+]
     },
     {
       "Sid": "DeployNewLambdaVersions",
@@ -34,7 +35,9 @@
         "lambda:GetLayerVersion"
       ],
       "Resource": [
-        "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:tecton-${DEPLOYMENT_NAME}*"
+        "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:tecton-*",
+        "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:layer:tecton-*",
+        "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:layer:push_writer_config_layer*"
       ]
     },
     {
@@ -46,7 +49,34 @@
         "kinesis:DescribeStreamSummary"
       ],
       "Resource": [
-        "arn:aws:kinesis:${REGION}:${ACCOUNT_ID}:id:stream/tecton-${DEPLOYMENT_NAME}*"
+        "arn:aws:kinesis:${REGION}:${ACCOUNT_ID}:stream/tecton-${DEPLOYMENT_NAME}*"
+      ]
+    },
+    {
+      "Sid": "ListResourcesForDiscovery",
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+
+        "kinesis:ListStreams"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "PassRoleForLambda",
+      "Effect": "Allow",
+      "Action": [
+          "iam:PassRole"
+      ],
+      "Resource": [
+          "arn:aws:iam::${ACCOUNT_ID}:role/tecton-*"
       ]
     }
   ]

--- a/templates/online_ingest_management_policy.json
+++ b/templates/online_ingest_management_policy.json
@@ -14,10 +14,7 @@
         "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:listener/app/tecton-${DEPLOYMENT_NAME}*",
         "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/net/tecton-*",
         "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/app/tecton-*",
-        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/tecton-${DEPLOYMENT_NAME}*",
-        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/${DEPLOYMENT_NAME}*",
-        "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup::autoScalingGroupName/tecton-${DEPLOYMENT_NAME}*",
-        "arn:aws:autoscaling:${REGION}:${ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/eks-*"
+        "arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:targetgroup/tecton-${DEPLOYMENT_NAME}*"
 ]
     },
     {
@@ -36,8 +33,7 @@
       ],
       "Resource": [
         "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:tecton-*",
-        "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:layer:tecton-*",
-        "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:layer:push_writer_config_layer*"
+        "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:layer:tecton-*"
       ]
     },
     {


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

The `Describe*` API need `resource: ["*"]` because specifying a prefix causes errors when calling these APIs. They also do not have the ability to specify a resource prefix when making the API call.