### PR TITLE
Add fargate roles for vpc customers to customer facing terraform.

### DIFF
--- a/databricks_sample/outputs.tf
+++ b/databricks_sample/outputs.tf
@@ -24,5 +24,7 @@ output "roles" {
     eks_node_role_name     = module.roles.eks_node_role_name
     online_ingest_role_arn = module.roles.online_ingest_role_arn
     offline_ingest_role_arn = module.roles.offline_ingest_role_arn
+    fargate_kinesis_firehose_stream_role_name = module.roles.fargate_kinesis_firehose_stream_role_name
+    fargate_eks_fargate_pod_execution_role_name = module.roles.fargate_eks_fargate_pod_execution_role_name
   }
 }

--- a/databricks_sample/outputs.tf
+++ b/databricks_sample/outputs.tf
@@ -19,12 +19,12 @@ output "security_group_ids" {
 
 output "roles" {
   value = {
-    devops_role_name       = module.roles.devops_role_name
-    eks_cluster_role_name  = module.roles.eks_management_role_name
-    eks_node_role_name     = module.roles.eks_node_role_name
-    online_ingest_role_arn = module.roles.online_ingest_role_arn
-    offline_ingest_role_arn = module.roles.offline_ingest_role_arn
-    fargate_kinesis_firehose_stream_role_name = module.roles.fargate_kinesis_firehose_stream_role_name
+    devops_role_name                            = module.roles.devops_role_name
+    eks_cluster_role_name                       = module.roles.eks_management_role_name
+    eks_node_role_name                          = module.roles.eks_node_role_name
+    online_ingest_role_arn                      = module.roles.online_ingest_role_arn
+    offline_ingest_role_arn                     = module.roles.offline_ingest_role_arn
+    fargate_kinesis_firehose_stream_role_name   = module.roles.fargate_kinesis_firehose_stream_role_name
     fargate_eks_fargate_pod_execution_role_name = module.roles.fargate_eks_fargate_pod_execution_role_name
   }
 }

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -83,6 +83,12 @@ variable "enable_eks_ingress_vpc_endpoint" {
   type        = bool
 }
 
+variable "fargate_enabled" {
+  default     = false
+  description = "Enable fargate on cluster."
+  type        = bool
+}
+
 module "eks_subnets" {
   providers = {
     aws = aws
@@ -160,6 +166,7 @@ module "roles" {
   create_emr_roles                = true
   elasticache_enabled             = var.elasticache_enabled
   external_id                     = random_id.external_id.id
+  fargate_enabled                 = var.fargate_enabled
 }
 
 module "notebook_cluster" {

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -38,5 +38,8 @@ output "roles" {
     spark_node_role_name    = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
     online_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
     offline_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
+    fargate_kinesis_firehose_stream_role_name = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
+    fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles.fargate_eks_fargate_pod_execution_role_name : ""
+
   }
 }

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -32,13 +32,13 @@ output "security_group_ids" {
 
 output "roles" {
   value = {
-    devops_role_name        = (var.apply_layer > 1) ? module.roles[0].devops_role_name : ""
-    eks_cluster_role_name   = (var.apply_layer > 1) ? module.roles[0].eks_management_role_name : ""
-    eks_node_role_name      = (var.apply_layer > 1) ? module.roles[0].eks_node_role_name : ""
-    spark_node_role_name    = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
-    online_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
-    offline_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
-    fargate_kinesis_firehose_stream_role_name = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
+    devops_role_name                            = (var.apply_layer > 1) ? module.roles[0].devops_role_name : ""
+    eks_cluster_role_name                       = (var.apply_layer > 1) ? module.roles[0].eks_management_role_name : ""
+    eks_node_role_name                          = (var.apply_layer > 1) ? module.roles[0].eks_node_role_name : ""
+    spark_node_role_name                        = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
+    online_ingest_role_arn                      = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
+    offline_ingest_role_arn                     = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
+    fargate_kinesis_firehose_stream_role_name   = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
     fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles.fargate_eks_fargate_pod_execution_role_name : ""
 
   }

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -38,8 +38,8 @@ output "roles" {
     spark_node_role_name                        = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
     online_ingest_role_arn                      = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
     offline_ingest_role_arn                     = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
-    fargate_kinesis_firehose_stream_role_name   = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
-    fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles.fargate_eks_fargate_pod_execution_role_name : ""
+    fargate_kinesis_firehose_stream_role_name   = (var.apply_layer > 1) ? module.roles[0].fargate_kinesis_firehose_stream_role_name : ""
+    fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles[0].fargate_eks_fargate_pod_execution_role_name : ""
 
   }
 }

--- a/roles/outputs.tf
+++ b/roles/outputs.tf
@@ -33,3 +33,11 @@ output "online_ingest_role_arn" {
 output "offline_ingest_role_arn" {
   value = aws_iam_role.online_ingest_role[0].arn
 }
+
+output "fargate_kinesis_firehose_stream_role_name" {
+  value = aws_iam_role.kinesis_firehose_stream[0].name
+}
+
+output "fargate_eks_fargate_pod_execution_role_name" {
+  value = aws_iam_role.eks_fargate_pod_execution[0].name
+}

--- a/roles/outputs.tf
+++ b/roles/outputs.tf
@@ -35,9 +35,9 @@ output "offline_ingest_role_arn" {
 }
 
 output "fargate_kinesis_firehose_stream_role_name" {
-  value = aws_iam_role.kinesis_firehose_stream[0].name
+  value = var.fargate_enabled ? aws_iam_role.kinesis_firehose_stream[0].name : ""
 }
 
 output "fargate_eks_fargate_pod_execution_role_name" {
-  value = aws_iam_role.eks_fargate_pod_execution[0].name
+  value = var.fargate_enabled ? aws_iam_role.eks_fargate_pod_execution[0].name : ""
 }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -710,7 +710,7 @@ data "aws_iam_policy_document" "fargate_logging_policy" {
     ]
     effect = "Allow"
     resources = [
-      locals.fargate_kinesis_delivery_stream_arn
+      local.fargate_kinesis_delivery_stream_arn
     ]
   }
 }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -1,5 +1,5 @@
 locals {
-  tags = { "tecton-accessible:${var.deployment_name}" : "true" }
+  tags                                = { "tecton-accessible:${var.deployment_name}" : "true" }
   fargate_kinesis_delivery_stream_arn = "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/tecton-${var.deployment_name}-fargate-log-delivery-stream"
 }
 

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -627,7 +627,7 @@ resource "aws_iam_service_linked_role" "eks-nodegroup" {
 }
 
 
-# FARGATE ROLES AND POLICIES
+# FARGATE [Common : Databricks and EMR]
 
 data "aws_iam_policy_document" "kinesis_firehose_stream" {
   count   = var.fargate_enabled ? 1 : 0

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -58,3 +58,9 @@ variable "enable_ingest_api" {
   type        = bool
   description = "Whether or not to enable resources supporting the Ingest API. Default: true."
 }
+
+variable "fargate_enabled" {
+  default     = false
+  type        = bool
+  description = "Whether or not to enable resources supporting Fargate. Default: false."
+}


### PR DESCRIPTION
Update roles that need to be in the ctf to provision access to the fargate resources(i.e delivery stream and the cross account logging permissions.

Terraform plan without `fargate_enabled` flag results in no changes.

Terraform plan with `fargate_enabled`.
https://pastebin.com/HaiBZC4g