### PR TITLE
Add fargate service account roles and policies to allow provisioning of fargate resources

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -70,6 +70,12 @@ provider "aws" {
   }
 }
 
+variable "fargate_enabled" {
+  default     = false
+  description = "Enable fargate on cluster."
+  type        = bool
+}
+
 provider "aws" {
   alias  = "databricks-account"
   region = var.region
@@ -96,6 +102,7 @@ module "roles" {
   databricks_account_id           = var.external_databricks_account_id
   tecton_assuming_account_id      = var.tecton_assuming_account_id
   elasticache_enabled             = var.elasticache_enabled
+  fargate_enabled                 = var.fargate_enabled
 }
 
 module "subnets" {

--- a/databricks_sample/outputs.tf
+++ b/databricks_sample/outputs.tf
@@ -24,5 +24,7 @@ output "roles" {
     eks_node_role_name     = module.roles.eks_node_role_name
     online_ingest_role_arn = module.roles.online_ingest_role_arn
     offline_ingest_role_arn = module.roles.offline_ingest_role_arn
+    fargate_kinesis_firehose_stream_role_name = module.roles.fargate_kinesis_firehose_stream_role_name
+    fargate_eks_fargate_pod_execution_role_name = module.roles.fargate_eks_fargate_pod_execution_role_name
   }
 }

--- a/databricks_sample/outputs.tf
+++ b/databricks_sample/outputs.tf
@@ -19,12 +19,12 @@ output "security_group_ids" {
 
 output "roles" {
   value = {
-    devops_role_name       = module.roles.devops_role_name
-    eks_cluster_role_name  = module.roles.eks_management_role_name
-    eks_node_role_name     = module.roles.eks_node_role_name
-    online_ingest_role_arn = module.roles.online_ingest_role_arn
-    offline_ingest_role_arn = module.roles.offline_ingest_role_arn
-    fargate_kinesis_firehose_stream_role_name = module.roles.fargate_kinesis_firehose_stream_role_name
+    devops_role_name                            = module.roles.devops_role_name
+    eks_cluster_role_name                       = module.roles.eks_management_role_name
+    eks_node_role_name                          = module.roles.eks_node_role_name
+    online_ingest_role_arn                      = module.roles.online_ingest_role_arn
+    offline_ingest_role_arn                     = module.roles.offline_ingest_role_arn
+    fargate_kinesis_firehose_stream_role_name   = module.roles.fargate_kinesis_firehose_stream_role_name
     fargate_eks_fargate_pod_execution_role_name = module.roles.fargate_eks_fargate_pod_execution_role_name
   }
 }

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -83,6 +83,12 @@ variable "enable_eks_ingress_vpc_endpoint" {
   type        = bool
 }
 
+variable "fargate_enabled" {
+  default     = false
+  description = "Enable fargate on cluster."
+  type        = bool
+}
+
 module "eks_subnets" {
   providers = {
     aws = aws
@@ -160,6 +166,7 @@ module "roles" {
   create_emr_roles                = true
   elasticache_enabled             = var.elasticache_enabled
   external_id                     = random_id.external_id.id
+  fargate_enabled                 = var.fargate_enabled
 }
 
 module "notebook_cluster" {

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -38,5 +38,8 @@ output "roles" {
     spark_node_role_name    = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
     online_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
     offline_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
+    fargate_kinesis_firehose_stream_role_name = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
+    fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles.fargate_eks_fargate_pod_execution_role_name : ""
+
   }
 }

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -32,13 +32,13 @@ output "security_group_ids" {
 
 output "roles" {
   value = {
-    devops_role_name        = (var.apply_layer > 1) ? module.roles[0].devops_role_name : ""
-    eks_cluster_role_name   = (var.apply_layer > 1) ? module.roles[0].eks_management_role_name : ""
-    eks_node_role_name      = (var.apply_layer > 1) ? module.roles[0].eks_node_role_name : ""
-    spark_node_role_name    = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
-    online_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
-    offline_ingest_role_arn = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
-    fargate_kinesis_firehose_stream_role_name = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
+    devops_role_name                            = (var.apply_layer > 1) ? module.roles[0].devops_role_name : ""
+    eks_cluster_role_name                       = (var.apply_layer > 1) ? module.roles[0].eks_management_role_name : ""
+    eks_node_role_name                          = (var.apply_layer > 1) ? module.roles[0].eks_node_role_name : ""
+    spark_node_role_name                        = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
+    online_ingest_role_arn                      = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
+    offline_ingest_role_arn                     = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
+    fargate_kinesis_firehose_stream_role_name   = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
     fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles.fargate_eks_fargate_pod_execution_role_name : ""
 
   }

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -38,8 +38,8 @@ output "roles" {
     spark_node_role_name                        = (var.apply_layer > 1) ? module.roles[0].spark_role_name : ""
     online_ingest_role_arn                      = (var.apply_layer > 1) ? module.roles[0].online_ingest_role_arn : ""
     offline_ingest_role_arn                     = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
-    fargate_kinesis_firehose_stream_role_name   = (var.apply_layer > 1) ? module.roles.fargate_kinesis_firehose_stream_role_name : ""
-    fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles.fargate_eks_fargate_pod_execution_role_name : ""
+    fargate_kinesis_firehose_stream_role_name   = (var.apply_layer > 1) ? module.roles[0].fargate_kinesis_firehose_stream_role_name : ""
+    fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles[0].fargate_eks_fargate_pod_execution_role_name : ""
 
   }
 }

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -40,6 +40,5 @@ output "roles" {
     offline_ingest_role_arn                     = (var.apply_layer > 1) ? module.roles[0].offline_ingest_role_arn : ""
     fargate_kinesis_firehose_stream_role_name   = (var.apply_layer > 1) ? module.roles[0].fargate_kinesis_firehose_stream_role_name : ""
     fargate_eks_fargate_pod_execution_role_name = (var.apply_layer > 1) ? module.roles[0].fargate_eks_fargate_pod_execution_role_name : ""
-
   }
 }

--- a/roles/outputs.tf
+++ b/roles/outputs.tf
@@ -41,3 +41,7 @@ output "fargate_kinesis_firehose_stream_role_name" {
 output "fargate_eks_fargate_pod_execution_role_name" {
   value = var.fargate_enabled ? aws_iam_role.eks_fargate_pod_execution[0].name : ""
 }
+
+output "eks_fargate_node_policy_arn" {
+  value = var.fargate_enabled ? aws_iam_policy.eks_fargate_node_policy[0].arn : ""
+}

--- a/roles/outputs.tf
+++ b/roles/outputs.tf
@@ -42,6 +42,6 @@ output "fargate_eks_fargate_pod_execution_role_name" {
   value = var.fargate_enabled ? aws_iam_role.eks_fargate_pod_execution[0].name : ""
 }
 
-output "eks_fargate_node_policy_arn" {
-  value = var.fargate_enabled ? aws_iam_policy.eks_fargate_node_policy[0].arn : ""
+output "eks_fargate_node_policy_name" {
+  value = var.fargate_enabled ? aws_iam_policy.eks_fargate_node_policy[0].name : ""
 }

--- a/roles/outputs.tf
+++ b/roles/outputs.tf
@@ -33,3 +33,11 @@ output "online_ingest_role_arn" {
 output "offline_ingest_role_arn" {
   value = aws_iam_role.online_ingest_role[0].arn
 }
+
+output "fargate_kinesis_firehose_stream_role_name" {
+  value = aws_iam_role.kinesis_firehose_stream[0].name
+}
+
+output "fargate_eks_fargate_pod_execution_role_name" {
+  value = aws_iam_role.eks_fargate_pod_execution[0].name
+}

--- a/roles/outputs.tf
+++ b/roles/outputs.tf
@@ -35,9 +35,9 @@ output "offline_ingest_role_arn" {
 }
 
 output "fargate_kinesis_firehose_stream_role_name" {
-  value = aws_iam_role.kinesis_firehose_stream[0].name
+  value = var.fargate_enabled ? aws_iam_role.kinesis_firehose_stream[0].name : ""
 }
 
 output "fargate_eks_fargate_pod_execution_role_name" {
-  value = aws_iam_role.eks_fargate_pod_execution[0].name
+  value = var.fargate_enabled ? aws_iam_role.eks_fargate_pod_execution[0].name : ""
 }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -710,7 +710,7 @@ data "aws_iam_policy_document" "fargate_logging_policy" {
     ]
     effect = "Allow"
     resources = [
-      locals.fargate_kinesis_delivery_stream_arn
+      local.fargate_kinesis_delivery_stream_arn
     ]
   }
 }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -1,6 +1,6 @@
 locals {
   tags                                = { "tecton-accessible:${var.deployment_name}" : "true" }
-  fargate_kinesis_delivery_stream_arn = "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/tecton-${var.deployment_name}-fargate-log-delivery-stream1"
+  fargate_kinesis_delivery_stream_arn = "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/tecton-${var.deployment_name}-fargate-log-delivery-stream"
 }
 
 # EKS [Common : Databricks and EMR]

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -88,6 +88,7 @@ data "template_file" "devops_eks_policy_json" {
     REGION          = var.region
   }
 }
+
 # EKS [Common : Databricks and EMR]
 data "template_file" "devops_eks_vpc_endpoint_policy_json" {
   count = var.enable_eks_ingress_vpc_endpoint ? 1 : 0
@@ -150,7 +151,6 @@ data "template_file" "emr_spark_policy_json" {
   count    = var.create_emr_roles ? 1 : 0
   template = file("${path.module}/../templates/emr_spark_policy.json")
   vars = {
-    ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
   }
@@ -219,7 +219,6 @@ resource "aws_iam_policy" "devops_fargate_policy" {
   tags   = local.tags
 }
 
-
 # DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_policy" "devops_eks_policy" {
   name   = "tecton-${var.deployment_name}-devops-eks-policy"
@@ -270,7 +269,6 @@ resource "aws_iam_role_policy_attachment" "devops_fargate_policy_attachment" {
   policy_arn = aws_iam_policy.devops_fargate_policy[0].arn
   role       = aws_iam_role.devops_role.name
 }
-
 
 # DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_role_policy_attachment" "devops_eks_policy_attachment" {
@@ -686,7 +684,6 @@ resource "aws_iam_service_linked_role" "eks-nodegroup" {
 resource "aws_iam_service_linked_role" "eks-fargate" {
   aws_service_name = "eks-fargate.amazonaws.com"
 }
-
 
 # FARGATE [Common : Databricks and EMR]
 data "aws_iam_policy_document" "kinesis_firehose_stream" {

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -1,6 +1,10 @@
 locals {
   tags                                = { "tecton-accessible:${var.deployment_name}" : "true" }
   fargate_kinesis_delivery_stream_arn = "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/tecton-${var.deployment_name}-fargate-log-delivery-stream"
+  common_tags = {
+      tecton-cluster-name = var.deployment_name
+      tecton-owned        = true
+  }
 }
 
 # EKS [Common : Databricks and EMR]
@@ -750,13 +754,13 @@ data "aws_iam_policy_document" "dummy_policy" {
 
 resource "aws_iam_role" "eks_fargate_feature_server_role" {
   count = var.fargate_enabled ? 1 : 0
-  name  = "${var.cluster_name}-fargate-fs"
+  name  = "tecton-${var.deployment_name}-fargate-fs"
   tags  = local.common_tags
   lifecycle {
     ignore_changes = [permissions_boundary]
   }
 
-  max_session_duration = var.worker_node_max_session_duration
+  max_session_duration = 28800
 
   assume_role_policy = data.aws_iam_policy_document.dummy_policy[0].json
 }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -1,6 +1,6 @@
 locals {
   tags                                = { "tecton-accessible:${var.deployment_name}" : "true" }
-  fargate_kinesis_delivery_stream_arn = "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/tecton-${var.deployment_name}-fargate-log-delivery-stream"
+  fargate_kinesis_delivery_stream_arn = "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/tecton-${var.deployment_name}-fargate-log-delivery-stream1"
 }
 
 # EKS [Common : Databricks and EMR]

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -300,6 +300,13 @@ resource "aws_iam_role_policy_attachment" "eks_management_policy" {
   role       = aws_iam_role.eks_management_role.name
 }
 
+# EKS VPC Management [Common : Databricks and EMR]
+resource "aws_iam_role_policy_attachment" "tecton-eks-cluster-AmazonEKSVPCResourceController" {
+  count      = var.fargate_enabled ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.eks_management_role.name
+}
+
 # EKS NODE [Common : Databricks and EMR]
 resource "aws_iam_role" "eks_node_role" {
   name               = "tecton-${var.deployment_name}-eks-worker-role"
@@ -674,7 +681,7 @@ data "aws_iam_policy_document" "kinesis_firehose_stream" {
 # Resources to enable logs output to S3
 resource "aws_iam_role" "kinesis_firehose_stream" {
   count              = var.fargate_enabled ? 1 : 0
-  name               = "tecton-${var.deployment_name}_fargate_kinesis_firehose"
+  name               = "tecton-${var.deployment_name}-fargate-kinesis-firehose"
   assume_role_policy = data.aws_iam_policy_document.kinesis_firehose_stream[0].json
 }
 

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -249,7 +249,6 @@ resource "aws_iam_role_policy_attachment" "devops_fargate_policy_attachment" {
 }
 
 
-
 # DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_role_policy_attachment" "devops_eks_policy_attachment" {
   policy_arn = aws_iam_policy.devops_eks_policy.arn

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -307,6 +307,8 @@ resource "aws_iam_role_policy_attachment" "tecton-eks-cluster-AmazonEKSVPCResour
   role       = aws_iam_role.eks_management_role.name
 }
 
+
+
 # EKS NODE [Common : Databricks and EMR]
 resource "aws_iam_role" "eks_node_role" {
   name               = "tecton-${var.deployment_name}-eks-worker-role"
@@ -658,6 +660,10 @@ resource "aws_iam_service_linked_role" "spot" {
 
 resource "aws_iam_service_linked_role" "eks-nodegroup" {
   aws_service_name = "eks-nodegroup.amazonaws.com"
+}
+
+resource "aws_iam_service_linked_role" "eks-fargate" {
+  aws_service_name = "eks-fargate.amazonaws.com"
 }
 
 

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -263,6 +263,7 @@ resource "aws_iam_role_policy_attachment" "devops_ingest_policy_attachment" {
   role       = aws_iam_role.devops_role.name
 }
 
+# DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_role_policy_attachment" "devops_fargate_policy_attachment" {
   count = var.fargate_enabled ? 1 : 0
 
@@ -328,8 +329,6 @@ resource "aws_iam_role_policy_attachment" "tecton-eks-cluster-AmazonEKSVPCResour
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
   role       = aws_iam_role.eks_management_role.name
 }
-
-
 
 # EKS NODE [Common : Databricks and EMR]
 resource "aws_iam_role" "eks_node_role" {
@@ -690,7 +689,6 @@ resource "aws_iam_service_linked_role" "eks-fargate" {
 
 
 # FARGATE [Common : Databricks and EMR]
-
 data "aws_iam_policy_document" "kinesis_firehose_stream" {
   count   = var.fargate_enabled ? 1 : 0
   version = "2012-10-17"

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -151,6 +151,7 @@ data "template_file" "emr_spark_policy_json" {
   count    = var.create_emr_roles ? 1 : 0
   template = file("${path.module}/../templates/emr_spark_policy.json")
   vars = {
+    ACCOUNT_ID      = var.account_id
     DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
   }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -1,5 +1,5 @@
 locals {
-  tags = { "tecton-accessible:${var.deployment_name}" : "true" }
+  tags                                = { "tecton-accessible:${var.deployment_name}" : "true" }
   fargate_kinesis_delivery_stream_arn = "arn:aws:firehose:${var.region}:${var.account_id}:deliverystream/tecton-${var.deployment_name}-fargate-log-delivery-stream"
 }
 

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -627,7 +627,7 @@ resource "aws_iam_service_linked_role" "eks-nodegroup" {
 }
 
 
-# FARGATE ROLES AND POLICIES
+# FARGATE [Common : Databricks and EMR]
 
 data "aws_iam_policy_document" "kinesis_firehose_stream" {
   count   = var.fargate_enabled ? 1 : 0

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -52,9 +52,10 @@ data "template_file" "eks_fargate_node" {
 
   template = file("${path.module}/../templates/fargate_eks_role.json")
   vars = {
-    ACCOUNT_ID      = var.account_id
-    DEPLOYMENT_NAME = var.deployment_name
-    REGION          = var.region
+    ACCOUNT_ID          = var.account_id
+    ASSUMING_ACCOUNT_ID = var.tecton_assuming_account_id
+    DEPLOYMENT_NAME     = var.deployment_name
+    REGION              = var.region
   }
 }
 
@@ -77,6 +78,15 @@ data "template_file" "devops_fargate_role_json" {
     REGION          = var.region
     FARGATE_POLICY_ARN      = aws_iam_policy.eks_fargate_node_policy[0].arn
   }
+}
+
+# DEVOPS [Common : Databricks and EMR]
+resource "aws_iam_policy" "devops_fargate_policy" {
+  count = var.fargate_enabled ? 1 : 0
+
+  name   = "tecton-${var.deployment_name}-devops-fargate-policy"
+  policy = data.template_file.devops_fargate_role_json[0].rendered
+  tags   = local.tags
 }
 
 # EKS [Common : Databricks and EMR]
@@ -208,15 +218,6 @@ resource "aws_iam_policy" "devops_ingest_policy" {
 
   name   = "tecton-${var.deployment_name}-devops-ingest-policy"
   policy = data.template_file.devops_ingest_policy_json[0].rendered
-  tags   = local.tags
-}
-
-# DEVOPS [Common : Databricks and EMR]
-resource "aws_iam_policy" "devops_fargate_policy" {
-  count = var.fargate_enabled ? 1 : 0
-
-  name   = "tecton-${var.deployment_name}-devops-fargate-policy"
-  policy = data.template_file.devops_fargate_role_json[0].rendered
   tags   = local.tags
 }
 

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -760,7 +760,7 @@ resource "aws_iam_role" "eks_fargate_feature_server_role" {
     ignore_changes = [permissions_boundary]
   }
 
-  max_session_duration = 28800
+  max_session_duration = 28800 # probably needs to be not hard coded
 
   assume_role_policy = data.aws_iam_policy_document.dummy_policy[0].json
 }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -73,10 +73,10 @@ data "template_file" "devops_fargate_role_json" {
   count    = var.fargate_enabled ? 1 : 0
   template = file("${path.module}/../templates/devops_fargate.json")
   vars = {
-    ACCOUNT_ID      = var.account_id
-    DEPLOYMENT_NAME = var.deployment_name
-    REGION          = var.region
-    FARGATE_POLICY_ARN      = aws_iam_policy.eks_fargate_node_policy[0].arn
+    ACCOUNT_ID         = var.account_id
+    DEPLOYMENT_NAME    = var.deployment_name
+    REGION             = var.region
+    FARGATE_POLICY_ARN = aws_iam_policy.eks_fargate_node_policy[0].arn
   }
 }
 

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -58,3 +58,9 @@ variable "enable_ingest_api" {
   type        = bool
   description = "Whether or not to enable resources supporting the Ingest API. Default: true."
 }
+
+variable "fargate_enabled" {
+  default     = false
+  type        = bool
+  description = "Whether or not to enable resources supporting Fargate. Default: false."
+}

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -75,7 +75,8 @@
             ],
             "Resource": [
                 "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*"
-            ]
+            ],
+            "Condition": {"StringEquals": {"aws:ResourceTag/tecton-owned": "true"}}
         },
         {
             "Sid": "EksFargateNodePolicyPolicies",

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -10,8 +10,7 @@
                 "iam:DescribeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
-                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-fargate-fs"
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-fs"
             ],
             "Condition": {
                 "StringEquals": {

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -1,0 +1,38 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "FargateAttachRole",
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole"
+                "iam:AttachRolePolicy",
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
+                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs", // honestly not sure which is which(the tecton header or no header)
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "iam:PolicyARN":
+                        [
+                            "arn:aws:iam::*:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy",
+                            "arn:aws:iam::*:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy",
+                        ]
+                }
+            }
+        },
+        {
+            "Sid": "CreateFargateRole",
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole",
+                "iam:CreateRole",
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
+                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs", // honestly not sure which is which
+            ],
+        },
+    ]
+}

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -6,7 +6,7 @@
             "Effect": "Allow",
             "Action": [
                 "iam:PassRole",
-                "iam:AttachRolePolicy",
+                "iam:AttachRolePolicy"
             ],
             "Resource": [
                 "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
@@ -33,17 +33,6 @@
             ]
         },
         {
-            "Sid": "GetRole",
-            "Effect": "Allow",
-            "Action": [
-                "iam:GetRole"
-
-            ],
-            "Resource": [
-                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}*"
-            ]
-        },
-        {
             "Sid": "KinesisStream",
             "Effect": "Allow",
             "Action": [
@@ -61,6 +50,8 @@
             "Effect": "Allow",
             "Action": [
                 "eks:CreateFargateProfile",
+                "eks:DescribeFargateProfile",
+                "eks:DeleteFargateProfile",
                 "eks:TagResource"
             ],
             "Resource": ["arn:aws:eks:${REGION}:${ACCOUNT_ID}:cluster/tecton-${DEPLOYMENT_NAME}*"]
@@ -70,9 +61,15 @@
             "Effect": "Allow",
             "Action": [
                 "iam:CreateOpenIDConnectProvider",
-                "iam:GetOpenIDConnectProvider"
+                "iam:DeleteOpenIDConnectProvider",
+                "iam:GetOpenIDConnectProvider",
+                "iam:ListOpenIDConnectProviders",
+                "iam:ListSAMLProviders"
             ],
-            "Resource": ["arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*"]
+            "Resource": [
+                "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*",
+                "arn:aws:iam::${ACCOUNT_ID}:saml-provider/*"
+            ]
         }
     ]
 }

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -5,19 +5,19 @@
             "Sid": "FargateAttachRole",
             "Effect": "Allow",
             "Action": [
-                "iam:PassRole"
-                "iam:AttachRolePolicy",
+                "iam:PassRole",
+                "iam:AttachRolePolicy"
             ],
             "Resource": [
                 "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
-                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs", // honestly not sure which is which(the tecton header or no header)
+                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs"
             ],
             "Condition": {
                 "StringEquals": {
                     "iam:PolicyARN":
                         [
                             "arn:aws:iam::*:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy",
-                            "arn:aws:iam::*:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy",
+                            "arn:aws:iam::*:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy"
                         ]
                 }
             }
@@ -27,12 +27,26 @@
             "Effect": "Allow",
             "Action": [
                 "iam:PassRole",
-                "iam:CreateRole",
+                "iam:CreateRole"
             ],
             "Resource": [
                 "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
-                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs", // honestly not sure which is which
-            ],
+                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs"
+            ]
         },
+        {
+            "Sid": "KinesisStream",
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:CreateStream",
+                "kinesis:DescribeStreamSummary",
+                "kinesis:IncreaseStreamRetentionPeriod",
+                "kinesis:ListTagsForStream",
+                "kinesis:EnableEnhancedMonitoring",
+                "kinesis:AddTagsToStream",
+                "kinesis:DeleteStream"
+            ],
+            "Resource": ["arn:aws:kinesis:${REGION}:${ACCOUNT_ID}:stream/tecton-${DEPLOYMENT_NAME}*"]
+        }
     ]
 }

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -6,7 +6,7 @@
             "Effect": "Allow",
             "Action": [
                 "iam:PassRole",
-                "iam:AttachRolePolicy"
+                "iam:AttachRolePolicy",
             ],
             "Resource": [
                 "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
@@ -16,8 +16,7 @@
                 "StringEquals": {
                     "iam:PolicyARN":
                         [
-                            "arn:aws:iam::*:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy",
-                            "arn:aws:iam::*:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy"
+                            "arn:aws:iam::${ACCOUNT_ID}:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy"
                         ]
                 }
             }
@@ -30,23 +29,50 @@
                 "iam:CreateRole"
             ],
             "Resource": [
-                "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
-                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs"
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-fs"
+            ]
+        },
+        {
+            "Sid": "GetRole",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole"
+
+            ],
+            "Resource": [
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}*"
             ]
         },
         {
             "Sid": "KinesisStream",
             "Effect": "Allow",
             "Action": [
-                "kinesis:CreateStream",
-                "kinesis:DescribeStreamSummary",
-                "kinesis:IncreaseStreamRetentionPeriod",
-                "kinesis:ListTagsForStream",
-                "kinesis:EnableEnhancedMonitoring",
-                "kinesis:AddTagsToStream",
-                "kinesis:DeleteStream"
+                "firehose:CreateDeliveryStream",
+                "firehose:UpdateDestination",
+                "firehose:DeleteDeliveryStream",
+                "firehose:DescribeDeliveryStream",
+                "kinesis:DescribeStream"
+
             ],
-            "Resource": ["arn:aws:kinesis:${REGION}:${ACCOUNT_ID}:stream/tecton-${DEPLOYMENT_NAME}*"]
+            "Resource": ["arn:aws:firehose:${REGION}:${ACCOUNT_ID}:deliverystream/tecton-${DEPLOYMENT_NAME}-fargate-log-delivery-stream"]
+        },
+        {
+            "Sid": "FargateProfile",
+            "Effect": "Allow",
+            "Action": [
+                "eks:CreateFargateProfile",
+                "eks:TagResource"
+            ],
+            "Resource": ["arn:aws:eks:${REGION}:${ACCOUNT_ID}:cluster/tecton-${DEPLOYMENT_NAME}*"]
+        },
+        {
+            "Sid": "OidcProvider",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateOpenIDConnectProvider",
+                "iam:GetOpenIDConnectProvider"
+            ],
+            "Resource": ["arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*"]
         }
     ]
 }

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -41,18 +41,11 @@
                 "firehose:CreateDeliveryStream",
                 "firehose:UpdateDestination",
                 "firehose:DeleteDeliveryStream",
-                "firehose:ListTagsForDeliveryStream"
-            ],
-            "Resource": ["arn:aws:firehose:${REGION}:${ACCOUNT_ID}:deliverystream/tecton-${DEPLOYMENT_NAME}-fargate-log-delivery-stream*"]
-        },
-        {
-            "Sid": "DescribeDeliveryStreams",
-            "Effect": "Allow",
-            "Action": [
+                "firehose:ListTagsForDeliveryStream",
                 "firehose:DescribeDeliveryStream",
                 "firehose:ListDeliveryStreams"
             ],
-            "Resource": ["*"]
+            "Resource": ["arn:aws:firehose:${REGION}:${ACCOUNT_ID}:deliverystream/tecton-${DEPLOYMENT_NAME}-fargate-log-delivery-stream*"]
         },
         {
             "Sid": "FargateProfile",

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -10,8 +10,8 @@
                 "iam:DescribeRole"
             ],
             "Resource": [
-                "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
-                "arn:aws:iam::*:role/${DEPLOYMENT_NAME}-fargate-fs"
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
+                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-fargate-fs"
             ],
             "Condition": {
                 "StringEquals": {
@@ -41,7 +41,8 @@
             "Action": [
                 "firehose:CreateDeliveryStream",
                 "firehose:UpdateDestination",
-                "firehose:DeleteDeliveryStream"
+                "firehose:DeleteDeliveryStream",
+                "firehose:ListTagsForDeliveryStream"
             ],
             "Resource": ["arn:aws:firehose:${REGION}:${ACCOUNT_ID}:deliverystream/tecton-${DEPLOYMENT_NAME}-fargate-log-delivery-stream*"]
         },
@@ -50,8 +51,7 @@
             "Effect": "Allow",
             "Action": [
                 "firehose:DescribeDeliveryStream",
-                "firehose:ListDeliveryStreams",
-                "firehose:DeleteDeliveryStream"
+                "firehose:ListDeliveryStreams"
             ],
             "Resource": ["*"]
         },
@@ -76,12 +76,10 @@
                 "iam:CreateOpenIDConnectProvider",
                 "iam:DeleteOpenIDConnectProvider",
                 "iam:GetOpenIDConnectProvider",
-                "iam:ListOpenIDConnectProviders",
-                "iam:ListSAMLProviders"
+                "iam:ListOpenIDConnectProviders"
             ],
             "Resource": [
-                "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*",
-                "arn:aws:iam::${ACCOUNT_ID}:saml-provider/*"
+                "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*"
             ]
         }
     ]

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -16,7 +16,7 @@
                 "StringEquals": {
                     "iam:PolicyARN":
                         [
-                            "arn:aws:iam::${ACCOUNT_ID}:policy/tecton-${DEPLOYMENT_NAME}-eks-fargate-node-policy"
+                            "${FARGATE_POLICY_ARN}"
                         ]
                 }
             }

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -76,6 +76,17 @@
             "Resource": [
                 "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*"
             ]
+        },
+        {
+            "Sid": "EksFargateNodePolicyPolicies",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListPolicies",
+                "iam:DescribePolicies"
+            ],
+            "Resource": [
+                "arn:aws:iam::${ACCOUNT_ID}:policy/*"
+            ]
         }
     ]
 }

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -71,7 +71,8 @@
                 "iam:CreateOpenIDConnectProvider",
                 "iam:DeleteOpenIDConnectProvider",
                 "iam:GetOpenIDConnectProvider",
-                "iam:ListOpenIDConnectProviders"
+                "iam:ListOpenIDConnectProviders",
+                "iam:TagOpenIDConnectProvider"
             ],
             "Resource": [
                 "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/*"

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -6,7 +6,8 @@
             "Effect": "Allow",
             "Action": [
                 "iam:PassRole",
-                "iam:AttachRolePolicy"
+                "iam:AttachRolePolicy",
+                "iam:DescribeRole"
             ],
             "Resource": [
                 "arn:aws:iam::*:role/tecton-${DEPLOYMENT_NAME}-fargate-fs",
@@ -26,7 +27,9 @@
             "Effect": "Allow",
             "Action": [
                 "iam:PassRole",
-                "iam:CreateRole"
+                "iam:CreateRole",
+                "iam:DescribeRole",
+                "iam:TagRole"
             ],
             "Resource": [
                 "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-fs"
@@ -38,12 +41,19 @@
             "Action": [
                 "firehose:CreateDeliveryStream",
                 "firehose:UpdateDestination",
-                "firehose:DeleteDeliveryStream",
-                "firehose:DescribeDeliveryStream",
-                "kinesis:DescribeStream"
-
+                "firehose:DeleteDeliveryStream"
             ],
-            "Resource": ["arn:aws:firehose:${REGION}:${ACCOUNT_ID}:deliverystream/tecton-${DEPLOYMENT_NAME}-fargate-log-delivery-stream"]
+            "Resource": ["arn:aws:firehose:${REGION}:${ACCOUNT_ID}:deliverystream/tecton-${DEPLOYMENT_NAME}-fargate-log-delivery-stream*"]
+        },
+        {
+            "Sid": "DescribeDeliveryStreams",
+            "Effect": "Allow",
+            "Action": [
+                "firehose:DescribeDeliveryStream",
+                "firehose:ListDeliveryStreams",
+                "firehose:DeleteDeliveryStream"
+            ],
+            "Resource": ["*"]
         },
         {
             "Sid": "FargateProfile",
@@ -54,10 +64,13 @@
                 "eks:DeleteFargateProfile",
                 "eks:TagResource"
             ],
-            "Resource": ["arn:aws:eks:${REGION}:${ACCOUNT_ID}:cluster/tecton-${DEPLOYMENT_NAME}*"]
+            "Resource": [
+                "arn:aws:eks:${REGION}:${ACCOUNT_ID}:cluster/tecton-${DEPLOYMENT_NAME}*",
+                "arn:aws:eks:${REGION}:${ACCOUNT_ID}:fargateprofile/tecton-${DEPLOYMENT_NAME}*"
+            ]
         },
         {
-            "Sid": "OidcProvider",
+            "Sid": "ProviderPermissions",
             "Effect": "Allow",
             "Action": [
                 "iam:CreateOpenIDConnectProvider",

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -7,7 +7,9 @@
             "Action": [
                 "iam:PassRole",
                 "iam:AttachRolePolicy",
-                "iam:DescribeRole"
+                "iam:DescribeRole",
+                "iam:DetachRolePolicy",
+                "iam:DeleteRolePolicy"
             ],
             "Resource": [
                 "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-fs"
@@ -28,7 +30,8 @@
                 "iam:PassRole",
                 "iam:CreateRole",
                 "iam:DescribeRole",
-                "iam:TagRole"
+                "iam:TagRole",
+                "iam:DeleteRole"
             ],
             "Resource": [
                 "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-fs"

--- a/templates/devops_policy_2.json
+++ b/templates/devops_policy_2.json
@@ -42,7 +42,8 @@
                 "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS",
                 "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/es.amazonaws.com/AWSServiceRoleForAmazonElasticsearchService",
                 "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing",
-                "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
+                "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",
+                "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/eks-fargate.amazonaws.com/AWSServiceRoleForAmazonEKSForFargate"
             ]
         },
         {

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -44,7 +44,7 @@
         }
       },
       {
-        "Sid": "AmazonS3Roles",
+        "Sid": "ReadWriteTectonS3Buckets",
         "Effect": "Allow",
         "Action": [
             "s3:GetObject",

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -2,7 +2,7 @@
     "Version": "2012-10-17",
     "Statement": [
       {
-        "Sid": "DynamoDBRoles",
+        "Sid": "TectonDynamoDBAccessPolicies",
         "Effect": "Allow",
         "Action": [
           "dynamodb:PutItem",
@@ -24,27 +24,7 @@
         ]
       },
       {
-        "Sid": "CloudwatchRoles",
-        "Effect": "Allow",
-        "Action": [
-            "cloudwatch:DescribeAlarmHistory",
-            "cloudwatch:DescribeAlarms",
-            "cloudwatch:DescribeAlarmsForMetric",
-            "cloudwatch:GetMetricStatistics",
-            "cloudwatch:ListMetrics",
-            "cloudwatch:PutMetricData"
-        ],
-        "Resource": [
-          "*"
-        ],
-        "Condition": {
-          "StringEquals": {
-              "cloudwatch:namespace": "tecton"
-          }
-        }
-      },
-      {
-        "Sid": "ReadWriteTectonS3Buckets",
+        "Sid": "ReadWriteTectonS3BucketsPolicies",
         "Effect": "Allow",
         "Action": [
             "s3:GetObject",
@@ -56,7 +36,7 @@
         ]
       },
       {
-        "Sid": "EC2ReadOnly",
+        "Sid": "TectonAmazonEC2ContainerRegistryReadOnlyPolicies",
         "Effect": "Allow",
         "Action": [
             "ecr:GetAuthorizationToken",
@@ -68,7 +48,9 @@
             "ecr:DescribeImages",
             "ecr:BatchGetImage"
         ],
-        "Resource": ["arn:aws:ecr:::*"]
+        "Resource": [
+          "arn:aws:ecr:${REGION}:${ACCOUNT_ID}:tecton/*"
+        ]
       }
     ]
   }

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -1,0 +1,74 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "DynamoDBRoles",
+        "Effect": "Allow",
+        "Action": [
+          "dynamodb:PutItem",
+          "dynamodb:DescribeStream",
+          "dynamodb:GetRecords",
+          "dynamodb:GetShardIterator",
+          "dynamodb:ListStreams",
+          "dynamodb:BatchGetItem",
+          "dynamodb:DescribeStream",
+          "dynamodb:DescribeTable",
+          "dynamodb:GetItem",
+          "dynamodb:ListStreams",
+          "dynamodb:ListTables",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+        ],
+        "Resource": [
+          "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*"
+        ]
+      },
+      {
+        "Sid": "CloudwatchRoles",
+        "Effect": "Allow",
+        "Action": [
+            "cloudwatch:DescribeAlarmHistory",
+            "cloudwatch:DescribeAlarms",
+            "cloudwatch:DescribeAlarmsForMetric",
+            "cloudwatch:GetMetricStatistics",
+            "cloudwatch:ListMetrics",
+          "cloudwatch:PutMetricData"
+        ],
+        "Resource": [
+          "*"
+        ],
+        "Condition": {
+          "StringEquals": {
+              "cloudwatch:namespace": "tecton"
+          }
+        }
+      },
+      {
+        "Sid": "AmazonS3Roles",
+        "Effect": "Allow",
+        "Action": [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject"
+        ],
+        "Resource": [
+            "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/*"
+        ]
+      },
+      {
+        "Sid": "EC2ReadOnly",
+        "Effect": "Allow",
+        "Action": [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:GetRepositoryPolicy",
+            "ecr:DescribeRepositories",
+            "ecr:ListImages",
+            "ecr:DescribeImages",
+            "ecr:BatchGetImage"
+        ],
+        "Resource": "*"
+    }
+    ]
+  }

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -50,8 +50,6 @@
         ],
         "Resource": [
           "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:tecton/*",
-          "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:mlflow-pyfunc",
-          "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:vouch/vouch-proxy"
         ]
       }
     ]

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -49,7 +49,7 @@
             "ecr:BatchGetImage"
         ],
         "Resource": [
-          "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:tecton/*",
+          "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:tecton/*"
         ]
       }
     ]

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -68,7 +68,7 @@
             "ecr:DescribeImages",
             "ecr:BatchGetImage"
         ],
-        "Resource": "*"
+        "Resource": ["arn:aws:ecr:::*"]
       }
     ]
   }

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -49,7 +49,7 @@
             "ecr:BatchGetImage"
         ],
         "Resource": [
-          "arn:aws:ecr:${REGION}:${ACCOUNT_ID}:tecton/*"
+          "arn:aws:ecr:${REGION}:${ASSUMING_ACCOUNT_ID}:tecton/*"
         ]
       }
     ]

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -49,7 +49,9 @@
             "ecr:BatchGetImage"
         ],
         "Resource": [
-          "arn:aws:ecr:${REGION}:${ASSUMING_ACCOUNT_ID}:tecton/*"
+          "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:tecton/*",
+          "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:mlflow-pyfunc",
+          "arn:aws:ecr:*:${ASSUMING_ACCOUNT_ID}:vouch/vouch-proxy"
         ]
       }
     ]

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -32,7 +32,7 @@
             "cloudwatch:DescribeAlarmsForMetric",
             "cloudwatch:GetMetricStatistics",
             "cloudwatch:ListMetrics",
-          "cloudwatch:PutMetricData"
+            "cloudwatch:PutMetricData"
         ],
         "Resource": [
           "*"

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -17,7 +17,7 @@
           "dynamodb:ListStreams",
           "dynamodb:ListTables",
           "dynamodb:Query",
-          "dynamodb:Scan",
+          "dynamodb:Scan"
         ],
         "Resource": [
           "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*"
@@ -69,6 +69,6 @@
             "ecr:BatchGetImage"
         ],
         "Resource": "*"
-    }
+      }
     ]
   }


### PR DESCRIPTION
Update roles that need to be in the ctf to provision access to the fargate resources(i.e delivery stream and the cross account logging permissions.

[Decisions](https://docs.google.com/document/d/16OItHy4D6C9jzvjmxX0jv_4Wqs0ROsXQPj3EvBMf8bM/edit)
