### PR TITLE
add GetItem permission to spark role

### DIFF
--- a/templates/spark_policy.json
+++ b/templates/spark_policy.json
@@ -8,6 +8,7 @@
                 "dynamodb:BatchWriteItem",
                 "dynamodb:ConditionCheckItem",
                 "dynamodb:DescribeTable",
+                "dynamodb:GetItem",
                 "dynamodb:PutItem",
                 "dynamodb:Query"
             ],


### PR DESCRIPTION
Adds GetItem permission to the role

New versions of delta LogStore as well as job synchronization changes
require dynamodb:GetItem in order to ensure concurrent jobs cannot overwrite each
other.
