### PR TITLE
perms: Add permissions to list and delete older lambda versions

### DIFF
--- a/templates/online_ingest_management_policy.json
+++ b/templates/online_ingest_management_policy.json
@@ -18,7 +18,7 @@
 ]
     },
     {
-      "Sid": "DeployNewLambdaVersions",
+      "Sid": "DeployNewLambdaVersionsAndPurgeOldVersions",
       "Effect": "Allow",
       "Action": [
         "lambda:AddPermission",
@@ -29,7 +29,9 @@
         "lambda:UpdateFunctionCode",
         "lambda:GetFunction",
         "lambda:PublishLayerVersion",
-        "lambda:GetLayerVersion"
+        "lambda:GetLayerVersion",
+        "lambda:ListVersionsByFunction",
+        "lambda:DeleteFunction"  
       ],
       "Resource": [
         "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:tecton-*",


### PR DESCRIPTION
We need to new permissions to make sure we're cleaning up older versions of the Lambda that are no longer in use.