### PR TITLE
fix: Add additional permissions needed for Lambda deployments

### DIFF
--- a/templates/online_ingest_management_policy.json
+++ b/templates/online_ingest_management_policy.json
@@ -31,7 +31,14 @@
         "lambda:PublishLayerVersion",
         "lambda:GetLayerVersion",
         "lambda:ListVersionsByFunction",
-        "lambda:DeleteFunction"  
+        "lambda:DeleteFunction",
+        "lambda:ListLayerVersions",
+        "lambda:DeleteLayerVersion",
+        "lambda:CreateAlias",
+        "lambda:DeleteAlias",
+        "lambda:ListAliases",
+        "lambda:GetAlias",
+        "lambda:UpdateAlias"  
       ],
       "Resource": [
         "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:tecton-*",
@@ -63,15 +70,19 @@
       ]
     },
     {
-      "Sid": "ListResourcesForDiscovery",
+      "Sid": "ManageLoadBalancerForwardingRules",
       "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTags",
         "elasticloadbalancing:DescribeListeners",
         "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets",
 
         "kinesis:ListStreams"
       ],


### PR DESCRIPTION
As title, we need some additional permissions to for lambda aliases and target registration/deregistration.