### PR TITLE
feat: tighter s3 controls + emr/notebook init args

### DIFF
--- a/deployment/buckets.tf
+++ b/deployment/buckets.tf
@@ -10,10 +10,21 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tecton_s3_bucket_
   bucket = aws_s3_bucket.tecton.id
 
   rule {
+    bucket_key_enabled = var.bucket_sse_algorithm == "aws:kms" ? var.bucket_sse_key_enabled : null
+
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm = var.bucket_sse_algorithm
     }
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "tecton" {
+  bucket = aws_s3_bucket.tecton.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_policy" "read-only-access" {
@@ -43,4 +54,11 @@ resource "aws_s3_bucket_ownership_controls" "bucket_owner_enforced" {
   rule {
     object_ownership = "BucketOwnerEnforced"
   }
+}
+
+resource "aws_s3_bucket_acl" "tecton" {
+  depends_on = [aws_s3_bucket_ownership_controls.bucket_owner_enforced]
+
+  bucket = aws_s3_bucket.tecton.id
+  acl    = "private"
 }

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -38,3 +38,19 @@ variable "additional_offline_storage_tags" {
   description = "Additional tags for offline storage (S3 bucket)"
   default     = {}
 }
+
+variable "bucket_sse_algorithm" {
+  default     = "AES256"
+  description = <<EOD
+Server-side encryption algorithm to use. Valid values are AES256 and aws:kms.
+ Note: (1) All resources should also be granted permission to decrypt with the KMS key if using KMS.
+       (2) If athena retrieval is used, the kms_key option must also be set on the athena session.
+EOD
+  type        = string
+}
+
+variable "bucket_sse_key_enabled" {
+  type        = bool
+  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
+  default     = null
+}

--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -73,6 +73,7 @@ locals {
         "s3://tecton.ai.public%s/install_scripts/setup_emr_notebook_cluster_v2.sh",
         lookup(local.bootstrap_regions, var.region, ""),
       )
+      args = var.bootstrap_tecton_emr_setup_args
     }
   ]
 }

--- a/emr/notebook_cluster/variables.tf
+++ b/emr/notebook_cluster/variables.tf
@@ -58,6 +58,13 @@ variable "emr_service_security_group_id" {
   type        = string
   description = "EMR service security group"
 }
+
+variable "bootstrap_tecton_emr_setup_args" {
+  default     = null
+  description = "Args to be passed to the default EMR setup bootstrap script"
+  type        = list(string)
+}
+
 variable "extra_bootstrap_actions" {
   type        = list(any)
   description = "Additional bootstrap actions to perform upon EMR creation"


### PR DESCRIPTION
# What

- [feat: tighter controls on bucket encryption/public](https://github.com/tecton-ai-ext/tecton-terraform-setup/commit/7451d3210492ef74473b1673b9f541f1ff18fa55)
- [feat(emr/notebook): allow args to be passed to default bootstrap](https://github.com/tecton-ai-ext/tecton-terraform-setup/commit/458c41af51c3087ad27e5027ea4c16239bac081f)