### PR TITLE
 feat(emr/notebook): allow args to be passed to default bootstrap

### DIFF
--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -60,10 +60,25 @@ locals {
     }
   ]
 
+  // bootstrap_regions
+  // ---
+  // EMR bootstrapping only supports bootstrap scripts from s3 buckets. The current way the s3
+  // client within EMR is retrieving the bootstrap scripts causes a failure to retrieve the file in
+  // certain regions. Currently Tecton supports serving bootstrap scripts from the following
+  // regions. (including us-west-2 by default) Reach out to customer support for further information.
+  bootstrap_regions = {
+    "eu-central-1" : "-eu-central-1",
+    "eu-west-1" : "-eu-west-1",
+    "us-east-2" : "-us-east-2",
+  }
+
   bootstrap_action = [
     {
       name = "tecton_emr_setup"
-      path = "s3://tecton.ai.public/install_scripts/setup_emr_notebook_cluster_v2.sh"
+      path = format(
+        "s3://tecton.ai.public%s/install_scripts/setup_emr_notebook_cluster_v2.sh",
+        lookup(local.bootstrap_regions, var.region, ""),
+      )
       args = var.bootstrap_tecton_emr_setup_args
     }
   ]

--- a/emr/notebook_cluster/main.tf
+++ b/emr/notebook_cluster/main.tf
@@ -64,6 +64,7 @@ locals {
     {
       name = "tecton_emr_setup"
       path = "s3://tecton.ai.public/install_scripts/setup_emr_notebook_cluster_v2.sh"
+      args = var.bootstrap_tecton_emr_setup_args
     }
   ]
 }

--- a/emr/notebook_cluster/variables.tf
+++ b/emr/notebook_cluster/variables.tf
@@ -42,12 +42,10 @@ variable "subnet_id" {
   type        = string
   description = "Subnet to install EMR into"
 }
-
 variable "instance_profile_arn" {
   type        = string
   description = "Underlying EC2 instance profile to use"
 }
-
 variable "emr_service_role_id" {
   type        = string
   description = "EMR service role"
@@ -61,6 +59,12 @@ variable "emr_security_group_id" {
 variable "emr_service_security_group_id" {
   type        = string
   description = "EMR service security group"
+}
+
+variable "bootstrap_tecton_emr_setup_args" {
+  default     = null
+  description = "Args to be passed to the default EMR setup bootstrap script"
+  type        = list(string)
 }
 
 variable "extra_bootstrap_actions" {


### PR DESCRIPTION
- [feat(emr/notebook): allow args to be passed to default bootstrap](https://github.com/tecton-ai-ext/tecton-terraform-setup/commit/eb55815d4f6835258e0d0c8056a5131cf80d379d)
- [fix: true-up bootstrap regions](https://github.com/tecton-ai-ext/tecton-terraform-setup/commit/fe3e7aa88c8ad0acc5de6cdb11cba3210fdb86f0)
    - Present in `master` branch, but missing here