### PR TITLE
[VPC] Allow data validation worker to put objects on S3

### DIFF
--- a/templates/data_validation_worker_policy.json
+++ b/templates/data_validation_worker_policy.json
@@ -20,6 +20,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetObject",
+        "s3:PutObject",
         "s3:ListBucket"
       ],
       "Resource": [


### PR DESCRIPTION
The data validation worker needs to put the validation results into Tecton's S3 bucket.