### PR TITLE
feat: add support for customer managed kms key

### DIFF
--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -80,3 +80,13 @@ resource "aws_iam_role_policy_attachment" "satellite_region_policy_attachment" {
   policy_arn = aws_iam_policy.satellite_region_policy[0].arn
   role       = local.spark_role_name
 }
+
+resource "aws_kms_key_policy" "cmk" {
+  key_id = var.kms_key_id
+  policy = templatefile("${path.module}/../templates/cmk_policy.json", {
+    ROLE_ARNS      = [
+        "arn:aws:iam::${var.account_id}:role/${local.spark_role_name}",
+        "arn:aws:iam::${var.tecton_assuming_account_id}:root",
+    ]
+  })
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -63,3 +63,9 @@ variable "bucket_sse_key_enabled" {
   description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
   default     = null
 }
+
+variable "kms_key_id" {
+  type = string
+  description = "ID of customer-managed key for encryptig data at rest"
+  default     = ""
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -65,7 +65,14 @@ variable "bucket_sse_key_enabled" {
 }
 
 variable "kms_key_id" {
-  type = string
-  description = "ID of customer-managed key for encryptig data at rest"
-  default     = ""
+  type        = string
+  description = "If provided, ID of customer-managed key for encryptig data at rest"
+  default     = null
 }
+
+variable "kms_key_additional_principals" {
+  type        = list(string)
+  description = "Additional set of principals to grant KMS key access to"
+  default     = []
+}
+

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -66,7 +66,7 @@ variable "bucket_sse_key_enabled" {
 
 variable "kms_key_id" {
   type        = string
-  description = "If provided, ID of customer-managed key for encryptig data at rest"
+  description = "If provided, ID of customer-managed key for encrypting data at rest"
   default     = null
 }
 

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.75"
+      version = "~> 4.60"
     }
   }
 }

--- a/templates/cmk_policy.json
+++ b/templates/cmk_policy.json
@@ -1,0 +1,38 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Allow use of the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ${jsonencode(ROLE_ARNS)}
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow attachment of persistent resources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ${jsonencode(ROLE_ARNS)}
+            },
+            "Action": [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                }
+            }
+        }
+    ]
+}

--- a/templates/cmk_policy.json
+++ b/templates/cmk_policy.json
@@ -2,6 +2,15 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${ACCOUNT_ID}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
             "Sid": "Allow use of the key",
             "Effect": "Allow",
             "Principal": {


### PR DESCRIPTION
Ported from https://github.com/tecton-ai/tecton/pull/14661
## What
1. Allow customer to specify a kms key by arn and grant permission for spark workers and tecton account to use it for encryption online/offline data store
2. upgrade aws provider version so it supports aws_kms_key_policy resource

## Test
test it by spinning up a new deployment and smoke test with granted permissions