### PR TITLE
feat: allow EMR roles to pull ECR images

### DIFF
--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -32,6 +32,11 @@ variable "create_emr_roles" {
   type    = bool
   default = false
 }
+variable "emr_read_ecr_repositories" {
+  type        = list(string)
+  description = "List of ECR repositories that EMR roles are granted read access to."
+  default     = []
+}
 variable "additional_s3_read_only_principals" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Ported from https://github.com/tecton-ai/tecton/pull/11346
# Summary (What and Why)
Goal: allow our EMR clusters to pull images from ECR to support running
Spark applications with Docker