### PR TITLE
chore: loosen up aws provider version contraints

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3"
+      version = "~> 4.60"
     }
   }
 }

--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3"
+      version = ">= 3"
     }
   }
 }

--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -80,3 +80,13 @@ resource "aws_iam_role_policy_attachment" "satellite_region_policy_attachment" {
   policy_arn = aws_iam_policy.satellite_region_policy[0].arn
   role       = local.spark_role_name
 }
+
+resource "aws_kms_key_policy" "cmk" {
+  key_id = var.kms_key_id
+  policy = templatefile("${path.module}/../templates/cmk_policy.json", {
+    ROLE_ARNS      = [
+        "arn:aws:iam::${var.account_id}:role/${local.spark_role_name}",
+        "arn:aws:iam::${var.tecton_assuming_account_id}:root",
+    ]
+  })
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -63,3 +63,9 @@ variable "bucket_sse_key_enabled" {
   description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
   default     = null
 }
+
+variable "kms_key_id" {
+  type = string
+  description = "ID of customer-managed key for encryptig data at rest"
+  default     = ""
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -65,7 +65,14 @@ variable "bucket_sse_key_enabled" {
 }
 
 variable "kms_key_id" {
-  type = string
-  description = "ID of customer-managed key for encryptig data at rest"
-  default     = ""
+  type        = string
+  description = "If provided, ID of customer-managed key for encryptig data at rest"
+  default     = null
 }
+
+variable "kms_key_additional_principals" {
+  type        = list(string)
+  description = "Additional set of principals to grant KMS key access to"
+  default     = []
+}
+

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -66,7 +66,7 @@ variable "bucket_sse_key_enabled" {
 
 variable "kms_key_id" {
   type        = string
-  description = "If provided, ID of customer-managed key for encryptig data at rest"
+  description = "If provided, ID of customer-managed key for encrypting data at rest"
   default     = null
 }
 

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.75"
+      version = "~> 4.60"
     }
   }
 }

--- a/emr/cross_account/main.tf
+++ b/emr/cross_account/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0.0"
+      version = "~> 4.60"
     }
   }
 }

--- a/emr/cross_account/main.tf
+++ b/emr/cross_account/main.tf
@@ -36,7 +36,7 @@ module "security_groups" {
 
 module "notebook_cluster" {
   source = "../notebook_cluster"
-  # See https://docs.tecton.ai/v2/setting-up-tecton/04b-connecting-emr.html#prerequisites
+  # See https://docs.tecton.ai/docs/setting-up-tecton/connecting-to-a-data-platform/tecton-on-emr/connecting-emr-notebooks#prerequisites
   # You must manually set the value of TECTON_API_KEY in AWS Secrets Manager
 
   # Set count = 1 once your Tecton rep confirms Tecton has been deployed in your account

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 3"
+      version               = ">= 3"
       configuration_aliases = [aws.cross_account]
     }
   }

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -58,17 +58,17 @@ module "subnets" {
 
 
 module "redis" {
-  source                   = "../emr/redis"
+  source = "../emr/redis"
   # See https://docs.tecton.ai/latest/setting-up-tecton/configuring-redis.html
   # By default Tecton comes with DynamoDB as the online store but you can optionally choose
   # to use Redis.
   # Enable by setting count to 1.
-  count                    = 0
-  redis_subnet_id          = module.subnets.emr_subnet_id
-  redis_security_group_id  = module.security_groups.emr_security_group_id
-  deployment_name          = local.deployment_name
+  count                   = 0
+  redis_subnet_id         = module.subnets.emr_subnet_id
+  redis_security_group_id = module.security_groups.emr_security_group_id
+  deployment_name         = local.deployment_name
 }
-  
+
 locals {
   # Set count = 1 once your Tecton rep confirms Tecton has been deployed in your account
   notebook_cluster_count = 0
@@ -79,7 +79,7 @@ locals {
 
 module "notebook_cluster" {
   source = "../emr/notebook_cluster"
-  # See https://docs.tecton.ai/v2/setting-up-tecton/04b-connecting-emr.html#prerequisites
+  # See https://docs.tecton.ai/docs/setting-up-tecton/connecting-to-a-data-platform/tecton-on-emr/connecting-emr-notebooks#prerequisites
   # You must manually set the value of TECTON_API_KEY in AWS Secrets Manager
 
   # Set count = 1 once your Tecton rep confirms Tecton has been deployed in your account

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 3"
+      version               = "~> 4.60"
       configuration_aliases = [aws.cross_account]
     }
   }

--- a/privatelink/cross_vpc/variables.tf
+++ b/privatelink/cross_vpc/variables.tf
@@ -4,7 +4,7 @@ variable "vpc_id" {
 }
 
 variable "dns_name" {
-  description = "DNS name for Tecton servcies"
+  description = "DNS name for Tecton services"
   type        = string
 }
 

--- a/templates/cmk_policy.json
+++ b/templates/cmk_policy.json
@@ -1,0 +1,38 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Allow use of the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ${jsonencode(ROLE_ARNS)}
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow attachment of persistent resources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ${jsonencode(ROLE_ARNS)}
+            },
+            "Action": [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                }
+            }
+        }
+    ]
+}

--- a/templates/cmk_policy.json
+++ b/templates/cmk_policy.json
@@ -2,6 +2,15 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${ACCOUNT_ID}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
             "Sid": "Allow use of the key",
             "Effect": "Allow",
             "Principal": {


### PR DESCRIPTION
## What
Loosen up aws provider version constraints from ~> 3 to -> 4.60

## Why
To incorporate recent aws provider upgrade: https://github.com/tecton-ai/tecton/pull/14661 to support aws_kms_key_policy resource.
