### PR TITLE
Aws v5 vpc

### DIFF
--- a/templates/devops_policy_2.json
+++ b/templates/devops_policy_2.json
@@ -100,13 +100,25 @@
             ]
         },
         {
+            "Sid": "RdsReadAccess",
+            "Action": [
+                "rds:DescribeDBInstances"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:rds:*:${ACCOUNT_ID}:db:*",
+                "arn:aws:rds:*:${ACCOUNT_ID}:subgrp:tecton-${DEPLOYMENT_NAME}*",
+                "arn:aws:rds:*:${ACCOUNT_ID}:og:default*",
+                "arn:aws:rds:*:${ACCOUNT_ID}:pg:default*"
+            ]
+        },
+        {
             "Sid": "RdsAccess",
             "Action": [
                 "rds:CreateDBSubnetGroup",
                 "rds:DeleteDBSubnetGroup",
                 "rds:AddTagsToResource",
                 "rds:DescribeDBSubnetGroups",
-                "rds:DescribeDBInstances",
                 "rds:ModifyDBInstance",
                 "rds:CreateDBInstance",
                 "rds:ListTagsForResource"


### PR DESCRIPTION
### What

Add missing permission `rds:DescribeDBInstances` over resource `arn:aws:rds:*:${ACCOUNT_ID}:db:*` as a result of upgrading to Terraform aws provider v5

### Test plan
test it against `dev-emr-vpc`