### PR TITLE
chore: fix terraform deprecation warning after upgrading to 1.5.7

### DIFF
--- a/emr/security_groups/versions.tf
+++ b/emr/security_groups/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/emr/vpc_subnets/versions.tf
+++ b/emr/vpc_subnets/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
As a result of upgrading Terraform to 1.x, fix `Warning: Reference to undefined provider` due to missing `required_provider` blocks in child modules. This change is already merged in main repo.