### PR TITLE
add missed param

### DIFF
--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -89,7 +89,8 @@ resource "aws_kms_key_policy" "cmk" {
   # unlike IAM policies, KMS key policies do not specify a resource.
   # The resource is the KMS key that is associated with the key policy
   policy = templatefile("${path.module}/../templates/cmk_policy.json", {
-    ROLE_ARNS = concat([
+    ACCOUNT_ID = var.account_id
+    ROLE_ARNS  = concat([
       "arn:aws:iam::${var.account_id}:role/${local.spark_role_name}",
       "arn:aws:iam::${var.tecton_assuming_account_id}:root",
     ], var.kms_key_additional_principals)


### PR DESCRIPTION
this fix is intended to resolve the error below

```tecton-terraform-setup/databricks_sample> aws-vault exec terraform -- terraform plan 
╷
│ Error: Invalid function argument
│ 
│   on ../deployment/roles.tf line 91, in resource "aws_kms_key_policy" "cmk":
│   91:   policy = templatefile("${path.module}/../templates/cmk_policy.json", {
│   92:     ROLE_ARNS = concat([
│   93:       "arn:aws:iam::${var.account_id}:role/${local.spark_role_name}",
│   94:       "arn:aws:iam::${var.tecton_assuming_account_id}:root",
│   95:     ], var.kms_key_additional_principals)
│   96:   })
│     ├────────────────
│     │ while calling templatefile(path, vars)
│     │ var.account_id is a string
│     │ var.kms_key_additional_principals is a list of string
│     │ var.tecton_assuming_account_id is a string
│ 
│ Invalid value for "vars" parameter: vars map does not contain key "ACCOUNT_ID", referenced at ../deployment/../templates/cmk_policy.json:8,40-50.
```
