### PR TITLE
fix: outputting s3 values only if they exist

### DIFF
--- a/roles/satellite.tf
+++ b/roles/satellite.tf
@@ -393,9 +393,9 @@ output "eks_satellite_management_role_name" {
 }
 
 output "s3_replication_policy_name" {
-  value = length(aws_iam_policy.s3_replication) > 0 ? aws_iam_policy.s3_replication[0].name : null
+  value = local.is_satellite_regions_enabled ? aws_iam_policy.s3_replication[0].name : null
 }
 
 output "s3_batch_replication_policy_name" {
-  value = length(aws_iam_policy.s3_batch_replication) > 0 ? aws_iam_policy.s3_batch_replication[0].name : null
+  value = local.is_satellite_regions_enabled ? aws_iam_policy.s3_batch_replication[0].name : null
 }

--- a/roles/satellite.tf
+++ b/roles/satellite.tf
@@ -393,9 +393,9 @@ output "eks_satellite_management_role_name" {
 }
 
 output "s3_replication_policy_name" {
-  value = aws_iam_policy.s3_replication[0].name
+  value = length(aws_iam_policy.s3_replication) > 0 ? aws_iam_policy.s3_replication[0].name : null
 }
 
 output "s3_batch_replication_policy_name" {
-  value = aws_iam_policy.s3_batch_replication[0].name
+  value = length(aws_iam_policy.s3_batch_replication) > 0 ? aws_iam_policy.s3_batch_replication[0].name : null
 }


### PR DESCRIPTION
# Summary (What and Why)
Customers are hitting errors when applying this terraform (see linked ticket). This updates the code to only fetch the output values if they exist, otherwise outputting `null`

# Test Plan
Running both `terraform plan` and `terraform validate` locally shows this is valid terraform, which will unblock this issue

# Rollout and Rollback Plan
[x] No special rollout plan - this change can be reverted if needed.
[ ] Rollout and rollback plan - Please fill this out for backwards-incompatible changes, such as changes to configuration or data models, or changes that need multiple steps to rollout correctly.

# JIRA
https://tecton.atlassian.net/browse/CS-4142