### PR TITLE
Remove unnecessary perms from SparkPolicy

### DIFF
--- a/templates/spark_policy.json
+++ b/templates/spark_policy.json
@@ -7,10 +7,8 @@
             "Action": [
                 "dynamodb:BatchWriteItem",
                 "dynamodb:ConditionCheckItem",
-                "dynamodb:DescribeImport",
                 "dynamodb:DescribeTable",
                 "dynamodb:GetItem",
-                "dynamodb:ImportTable",
                 "dynamodb:PutItem",
                 "dynamodb:Query"
             ],
@@ -59,23 +57,6 @@
                 "arn:aws:s3:::tecton.ai.databricks-init-scripts/*",
                 "arn:aws:s3:::tecton.ai.public*",
                 "arn:aws:s3:::tecton-materialization-release/*"
-            ]
-        },
-        {
-            "Sid": "CloudwatchLogging",
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:DescribeLogGroups",
-                "logs:DescribeLogStreams",
-                "logs:PutLogEvents",
-                "logs:PutRetentionPolicy"
-            ],
-            "Resource": [
-                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws-dynamodb/imports:*",
-                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws-dynamodb/imports:log-stream:*",
-                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group::log-stream:*"
             ]
         }
     ]


### PR DESCRIPTION
We don't need these perms here (in Spark) we only need them in the control plane where we call createtable.